### PR TITLE
Add a unit test to show how Clojure maps can be serialised by the client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,5 +12,6 @@
           :metadata {:doc/format :markdown}}
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
                                   [criterium "0.4.4"]
-                                  [cheshire "5.8.1"]]
+                                  [cheshire "5.8.1"]
+                                  [com.fasterxml.jackson.core/jackson-databind "2.9.8"]]
                    :global-vars {*warn-on-reflection* true}}})


### PR DESCRIPTION
The default Java serialization actually works. It is probably slow and
Wasteful, and the deserialisation returns a Java.Util.HashMap which has
The correct values.
The test demonstrates an easy solution to convert it back to Clojure
Map using JSON.