### PR TITLE
Adding support for multi-bin records

### DIFF
--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -16,7 +16,7 @@
 
 (def MAX_KEY_LENGTH (dec (bit-shift-left 1 13)))
 
-(def MAX_BIN_NAME_LENGTH (- (bit-shift-left 1 4) 2)) ;; 14
+(def MAX_BIN_NAME_LENGTH 14)
 
 (defprotocol IAerospikeClient
   (get-client [ac] [ac index] "Returns the relevant AerospikeClient object for the specific shard")
@@ -304,7 +304,7 @@
    (_put db
          index
          ((:transcoder conf identity) new-data)
-         (policy/update-bins-policy (get-client db) new-expiration)
+         (policy/update-only-policy (get-client db) new-expiration)
          set-name)))
 
 (defn touch
@@ -360,7 +360,7 @@
    (_delete-bins db
                  index
                  ((:transcoder conf identity) bin-keys)
-                 (policy/update-bins-policy (get-client db) new-expiration)
+                 (policy/update-only-policy (get-client db) new-expiration)
                  set-name)))
 
 ;; operate

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -349,7 +349,7 @@
           ^WriteListener (reify-write-listener op-future)
           ^WritePolicy policy
           (create-key (:dbns db) set-name index)
-          ^"[Lcom.aerospike.client.Bin;" (into-array Bin (mapv #(set-bin-as-null %) bin-names)))
+          ^"[Lcom.aerospike.client.Bin;" (into-array Bin (mapv set-bin-as-null bin-names)))
     (register-events op-future db "write" index start-time)))
 
 (defn delete-bins

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -129,42 +129,59 @@
     (throw (Exception. (format "%s is %s characters. Bin names have to be <= 14 characters..." bin-name (.length bin-name)))))
   (Bin. bin-name bin-value))
 
+(defn- ^Bin set-bin-as-null [^String bin-name]
+  (when (< MAX_BIN_NAME_LENGTH (.length bin-name))
+    (throw (Exception. (format "%s is %s characters. Bin names have to be <= 14 characters..." bin-name (.length bin-name)))))
+  (Bin/asNull bin-name))
+
 ;; get
 (defrecord AerospikeRecord [payload ^Integer gen ^Integer ttl])
 
 (defn- record->map [^Record record]
   (and record
-       (->AerospikeRecord
-         (get (.bins ^Record record) "")
-         ^Integer (.generation ^Record record)
-         ^Integer (.expiration ^Record record))))
+    (let [bins      (into {} (.bins ^Record record)) ;; converting from java.util.HashMap to a Clojure map
+          bin-names (mapv first bins)]
+      (->AerospikeRecord
+        (if (utils/single-bin? bin-names)
+          (utils/desanitize-bin-value (get bins ""))
+          (reduce-kv (fn [m k v]
+                       (assoc m (keyword k) (utils/desanitize-bin-value v)))
+            {}
+            bins))
+        ^Integer (.generation ^Record record)
+        ^Integer (.expiration ^Record record)))))
 
-(defn- record->bins->map [^Record record]
-  (and record
-    (->AerospikeRecord
-      ;; reduce-kv is used to reconstuct stored keys and values to Clojure types
-      ;; The extra (into {} ...) is there because (.bins record) returns
-      ;; java.util.Hashmap when a Clojure map type is needed instead
-      (reduce-kv (fn [m k v]
-                   (assoc m (keyword k) (utils/desanitize-bin-value v)))
-        {}
-        (into {} (.bins ^Record record)))
-      ^Integer (.generation ^Record record)
-      ^Integer (.expiration ^Record record))))
+(defn- map->multiple-bins [^IPersistentMap m]
+  (let [bins (for [[k v] m]
+               (create-bin (name k) (utils/sanitize-bin-value v)))]
+    (into-array Bin bins)))
+
+(defn- data->bins
+  "Function to identify whether `data` will be stored as a single or multiple bin record.
+  Only Clojure maps will default to multiple bins. Nested data structures are supported."
+  [data]
+  (if (map? data)
+    (map->multiple-bins data)
+    (into-array Bin [^Bin (Bin. "" (utils/sanitize-bin-value data))])))
 
 (defn get-single
   "Returns a single record: `(transcoder AerospikeRecord)`. The default transcoder is `identity`.
   Pass a `:policy` in `conf` to use a non-default `ReadPolicy`"
-  ([db index set-name] (get-single db index set-name {}))
-  ([db index set-name conf]
+  ([db index set-name] (get-single db index set-name [:all] {}))
+  ([db index set-name ^IPersistentVector bin-keys] (get-single db index set-name bin-keys {}))
+  ([db index set-name ^IPersistentVector bin-keys conf]
    (let [client (get-client db index)
          op-future (d/deferred)
-         start-time (System/nanoTime)]
+         start-time (System/nanoTime)
+         bin-names (mapv name bin-keys)] ;; bin-names can only be stored as strings in Aerospike
      (.get ^AerospikeClient client
            ^EventLoop (.next ^NioEventLoops (:el db))
            (reify-record-listener op-future)
            ^Policy (:policy conf)
-           (create-key (:dbns db) set-name index))
+           (create-key (:dbns db) set-name index)
+           ^"[Lcom.aerospike.client.Bin;" (if (= [:all] bin-keys)
+                                            (if (utils/single-bin? bin-names) bin-names nil)
+                                            (into-array String bin-names)))
      (let [d (d/chain' op-future
                        record->map
                        (:transcoder conf identity))]
@@ -178,32 +195,8 @@
    (get-multiple db indices sets {}))
   ([db indices sets conf]
    (apply d/zip'
-          (map (fn [[index set-name]] (get-single db index set-name conf))
+          (map (fn [[index set-name]] (get-single db index set-name [:all] conf))
                (map vector indices sets)))))
-
-(defn get-single-with-bins
-  "Returns a single record with a map of bins as the payload. If no bin-keys are specified or [:all]
-  is passed as an argument for bin-keys, then all bin-names associated with this record will be
-  returned. Pass a vector of keywords to return only those bins in the payload."
-  ([db index set-name] (get-single-with-bins db index set-name [:all] {}))
-  ([db index set-name ^IPersistentVector bin-keys] (get-single-with-bins db index set-name bin-keys {}))
-  ([db index set-name ^IPersistentVector bin-keys conf]
-   (let [client (get-client db index)
-         op-future (d/deferred)
-         start-time (System/nanoTime)
-         bin-names (map name bin-keys)] ;; bin-names can only be stored as strings in Aerospike
-     (.get ^AerospikeClient client
-           ^EventLoop (.next ^NioEventLoops (:el db))
-           (reify-record-listener op-future)
-           ^Policy (:policy conf)
-           (create-key (:dbns db) set-name index)
-           ^"[Lcom.aerospike.client.Bin;" (if (= [:all] bin-keys)
-                                            nil
-                                            (into-array String bin-names)))
-     (let [d (d/chain' op-future
-                       record->bins->map
-                       (:transcoder conf identity))]
-       (register-events d db "read" index start-time)))))
 
 (defn exists?
   "Test if an index exists."
@@ -221,23 +214,14 @@
 
 (defn get-single-no-meta
   "Shorthand to return a single record payload only."
-  [db index set-name]
-  (get-single db index set-name {:transcoder :payload}))
-
-(defn get-single-all-bins-no-meta
-  "Shorthand to return a single record payload with a map of bins."
-  [db index set-name]
-  (get-single-with-bins db index set-name [:all] {:transcoder :payload}))
+  ([db index set-name] (get-single db index set-name [:all] {:transcoder :payload}))
+  ([db index set-name ^IPersistentVector bin-keys]
+    (get-single db index set-name bin-keys {:transcoder :payload})))
 
 ;; put
-(defn- data->bins [^IPersistentMap data]
-  (let [bins (for [[k v] data]
-               (create-bin (name k) (utils/sanitize-bin-value v)))]
-    (into-array Bin bins)))
-
 (defn- _put [db index data policy set-name]
   (let [client (get-client db index)
-        bins (into-array Bin [^Bin (Bin. "" data)])
+        bins (data->bins data)
         op-future (d/deferred)
         start-time (System/nanoTime)]
     (.put ^AerospikeClient client
@@ -252,7 +236,10 @@
   "Writes `data` into a record with the key `index`, with the ttl of `expiration` seconds.
   `index` should be string. Pass a function in `(:trascoder conf)` to modify `data` before it
   is sent to the DB.
-  Pass a `WritePolicy` in `(:policy conf)` to uses the non-default policy."
+  Pass a `WritePolicy` in `(:policy conf)` to uses the non-default policy.
+  When a Clojure map is provided for the `data` argument, a multiple bin record will be created.
+  Each key-value pair in the map will be treated as a bin-name, bin-value pair. Bin-values can
+  be any nested data structure."
   ([db index set-name data expiration] (put db index set-name data expiration {}))
   ([db index set-name data expiration conf]
    (_put db
@@ -272,37 +259,6 @@
                  (put db index set-name payload expiration conf))
                (map vector indices set-names payloads expirations)))))
 
-(defn- _put-with-bins [db index ^IPersistentMap data policy set-name]
-  (let [client (get-client db index)
-        bins (data->bins data)
-        op-future (d/deferred)
-        start-time (System/nanoTime)]
-    (.put ^AerospikeClient client
-          ^EventLoop (.next ^NioEventLoops (:el db))
-          ^WriteListener (reify-write-listener op-future)
-          ^WritePolicy policy
-          (create-key (:dbns db) set-name index)
-          ^"[Lcom.aerospike.client.Bin;" bins)
-    (register-events op-future db "write" index start-time)))
-
-(defn put-with-bins
-  "Writes `data` into a record with the key `index`, with the ttl of `expiration` seconds.
-  `index` should be string. Bins are the Aerospike equivalent of columns. The `data` passed
-  into this function should be a Clojure map. Each key-value pair will be converted into an
-  Aerospike bin. There is no limit to how many bins a record can hold, however, the limit
-  for bins in a namespace is 32,767. Bin values can be nested data structures.
-  Pass a function in `(:trascoder conf)` to modify `data` before it
-  is sent to the DB.
-  Pass a `WritePolicy` in `(:policy conf)` to uses the non-default policy."
-  ([db index set-name ^IPersistentMap data expiration]
-   (put-with-bins db index set-name data expiration {}))
-  ([db index set-name ^IPersistentMap data expiration conf]
-   (_put-with-bins db
-                   index
-                   ((:transcoder conf identity) data)
-                   (:policy conf (policy/write-policy (get-client db) expiration))
-                   set-name)))
-
 (defn create
   "`put` with a create-only policy"
   ([db index set-name data expiration]
@@ -313,41 +269,6 @@
          ((:transcoder conf identity) data)
          (policy/create-only-policy (get-client db) expiration)
          set-name)))
-
-(defn create-with-bins
-  "`put-with-bins` with a create-only policy"
-  ([db index set-name ^IPersistentMap data expiration]
-   (create-with-bins db index set-name data expiration {}))
-  ([db index set-name ^IPersistentMap data expiration conf]
-   (_put-with-bins db
-                   index
-                   ((:transcoder conf identity) data)
-                   (policy/create-only-policy (get-client db) expiration)
-                   set-name)))
-
-(defn add-bins-to-record
-  "With an existing record in the database, this function accepts `new-data` as a Clojure
-  map and merges it with the current data in the record. All key-value pairs in the `new-data`
-  will also be converted to Aerospike bins. The `new-payload` is saved to the database after
-  the bins are added."
-  ([db index set-name ^IPersistentMap new-data new-expiration]
-   (add-bins-to-record db index set-name new-data new-expiration {}))
-  ([db index set-name ^IPersistentMap new-data new-expiration conf]
-   (let [current-data (deref (get-single-all-bins-no-meta db index set-name))
-         new-payload  (merge current-data new-data)]
-     (put-with-bins db index set-name new-payload new-expiration conf))))
-
-(defn remove-bins-from-record
-  "With an existing record in the database, this function accepts a vector of keywords
-  called `bin-keys` similar to `get-single-with-bins`. Once the record is retrieved, the
-  specified `bin-keys` are then removed from the record and the `new-payload` is saved to
-  the database."
-  ([db index set-name ^IPersistentVector bin-keys new-expiration]
-   (remove-bins-from-record db index set-name bin-keys new-expiration {}))
-  ([db index set-name ^IPersistentVector bin-keys new-expiration conf]
-   (let [current-data (deref (get-single-all-bins-no-meta db index set-name))
-         new-payload  (apply dissoc current-data bin-keys)]
-     (put-with-bins db index set-name new-payload new-expiration conf))))
 
 (defn replace-only
   "`put` with a replace-only policy"
@@ -372,6 +293,18 @@
          index
          ((:transcoder conf identity) new-record)
          (policy/update-policy (get-client db) generation new-expiration)
+         set-name)))
+
+(defn add-bins
+  "Add bins to an existing record without modifying old data. The `new-data` must be a
+  Clojure map."
+  ([db index set-name ^IPersistentMap new-data new-expiration]
+   (add-bins db index set-name new-data new-expiration {}))
+  ([db index set-name ^IPersistentMap new-data new-expiration conf]
+   (_put db
+         index
+         ((:transcoder conf identity) new-data)
+         (policy/update-bins-policy (get-client db) new-expiration)
          set-name)))
 
 (defn touch
@@ -406,6 +339,30 @@
               (create-key (:dbns db) set-name index))
      (register-events op-future db "delete" index start-time))))
 
+(defn- _delete-bins [db index bin-keys policy set-name]
+  (let [client (get-client db index)
+        op-future (d/deferred)
+        start-time (System/nanoTime)
+        bin-names (mapv name bin-keys)]
+    (.put ^AerospikeClient client
+          ^EventLoop (.next ^NioEventLoops (:el db))
+          ^WriteListener (reify-write-listener op-future)
+          ^WritePolicy policy
+          (create-key (:dbns db) set-name index)
+          ^"[Lcom.aerospike.client.Bin;" (into-array Bin (mapv #(set-bin-as-null %) bin-names)))
+    (register-events op-future db "write" index start-time)))
+
+(defn delete-bins
+  "Delete bins from an existing record. The `bin-keys` must be a vector of keywords."
+  ([db index set-name ^IPersistentVector bin-keys new-expiration]
+   (delete-bins db index set-name bin-keys new-expiration {}))
+  ([db index set-name ^IPersistentVector bin-keys new-expiration conf]
+   (_delete-bins db
+                 index
+                 ((:transcoder conf identity) bin-keys)
+                 (policy/update-bins-policy (get-client db) new-expiration)
+                 set-name)))
+
 ;; operate
 
 (defn operate
@@ -422,7 +379,7 @@
            op-future (d/deferred)
            start-time (System/nanoTime)]
        (.operate ^AerospikeClient client
-                 ^EventLoop (.next^NioEventLoops (:el db))
+                 ^EventLoop (.next ^NioEventLoops (:el db))
                  ^RecordListener (reify-record-listener op-future)
                  ^WritePolicy (:policy conf (policy/write-policy client expiration RecordExistsAction/UPDATE))
                  (create-key (:dbns db) set-name index)
@@ -457,8 +414,8 @@
     (try
       @(create db k set-name v ttl)
       (= v
-         @(get-single db k set-name {:transcoder :payload
-                                     :policy read-policy}))
+         @(get-single db k set-name [:all] {:transcoder :payload
+                                            :policy read-policy}))
       (catch Exception ex
         false))))
 

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -193,16 +193,16 @@
          start-time (System/nanoTime)
          bin-names (map name bin-keys)] ;; bin-names can only be stored as strings in Aerospike
      (.get ^AerospikeClient client
-       ^EventLoop (.next ^NioEventLoops (:el db))
-       (reify-record-listener op-future)
-       ^Policy (:policy conf)
-       (create-key (:dbns db) set-name index)
-       ^"[Lcom.aerospike.client.Bin;" (if (= [:all] bin-keys)
-                                        nil
-                                        (into-array String bin-names)))
+           ^EventLoop (.next ^NioEventLoops (:el db))
+           (reify-record-listener op-future)
+           ^Policy (:policy conf)
+           (create-key (:dbns db) set-name index)
+           ^"[Lcom.aerospike.client.Bin;" (if (= [:all] bin-keys)
+                                            nil
+                                            (into-array String bin-names)))
      (let [d (d/chain' op-future
-               record->bins->map
-               (:transcoder conf identity))]
+                       record->bins->map
+                       (:transcoder conf identity))]
        (register-events d db "read" index start-time)))))
 
 (defn exists?
@@ -278,11 +278,11 @@
         op-future (d/deferred)
         start-time (System/nanoTime)]
     (.put ^AerospikeClient client
-      ^EventLoop (.next ^NioEventLoops (:el db))
-      ^WriteListener (reify-write-listener op-future)
-      ^WritePolicy policy
-      (create-key (:dbns db) set-name index)
-      ^"[Lcom.aerospike.client.Bin;" bins)
+          ^EventLoop (.next ^NioEventLoops (:el db))
+          ^WriteListener (reify-write-listener op-future)
+          ^WritePolicy policy
+          (create-key (:dbns db) set-name index)
+          ^"[Lcom.aerospike.client.Bin;" bins)
     (register-events op-future db "write" index start-time)))
 
 (defn put-with-bins
@@ -298,10 +298,10 @@
    (put-with-bins db index set-name data expiration {}))
   ([db index set-name ^IPersistentMap data expiration conf]
    (_put-with-bins db
-     index
-     ((:transcoder conf identity) data)
-     (:policy conf (policy/write-policy (get-client db) expiration))
-     set-name)))
+                   index
+                   ((:transcoder conf identity) data)
+                   (:policy conf (policy/write-policy (get-client db) expiration))
+                   set-name)))
 
 (defn create
   "`put` with a create-only policy"
@@ -320,10 +320,10 @@
    (create-with-bins db index set-name data expiration {}))
   ([db index set-name ^IPersistentMap data expiration conf]
    (_put-with-bins db
-     index
-     ((:transcoder conf identity) data)
-     (policy/create-only-policy (get-client db) expiration)
-     set-name)))
+                   index
+                   ((:transcoder conf identity) data)
+                   (policy/create-only-policy (get-client db) expiration)
+                   set-name)))
 
 (defn add-bins-to-record
   "With an existing record in the database, this function accepts `new-data` as a Clojure

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -188,7 +188,12 @@
            ^Policy (:policy conf)
            (create-key (:dbns db) set-name index)
            ^"[Lcom.aerospike.client.Bin;" (if (= [:all] bin-names)
-                                            (if (utils/single-bin? bin-names) bin-names nil)
+                                            (if (utils/single-bin? bin-names)
+                                              bin-names
+                                              ;; 'nil' as the last value for .get invokes a different version of the
+                                              ;; method and retrieves all bins for multi-bin records
+                                              nil)
+                                            ;; if `bin-names` are provided, only returns those bins
                                             (into-array String bin-names)))
      (let [d (d/chain' op-future
                        record->map
@@ -222,7 +227,7 @@
 
 (defn get-single-no-meta
   "Shorthand to return a single record payload only."
-  ([db index set-name] (get-single db index set-name {:transcoder :payload} [:all]))
+  ([db index set-name] (get-single db index set-name {:transcoder :payload}))
   ([db index set-name ^IPersistentVector bin-names]
     (get-single db index set-name {:transcoder :payload} bin-names)))
 
@@ -422,7 +427,7 @@
       @(create db k set-name v ttl)
       (= v
          @(get-single db k set-name {:transcoder :payload
-                                     :policy read-policy} [:all]))
+                                     :policy read-policy}))
       (catch Exception ex
         false))))
 

--- a/src/aerospike_clj/policy.clj
+++ b/src/aerospike_clj/policy.clj
@@ -83,7 +83,7 @@
     (set! (.recordExistsAction wp) RecordExistsAction/REPLACE_ONLY)
     wp))
 
-(defn ^WritePolicy update-bins-policy
+(defn ^WritePolicy update-only-policy
   "Create a write policy with UPDATE_ONLY record exists action. The policy helps add/delete bins in
   records without replacing existing data."
   [client new-expiration]

--- a/src/aerospike_clj/policy.clj
+++ b/src/aerospike_clj/policy.clj
@@ -83,6 +83,14 @@
     (set! (.recordExistsAction wp) RecordExistsAction/REPLACE_ONLY)
     wp))
 
+(defn ^WritePolicy update-bins-policy
+  "Create a write policy with UPDATE_ONLY record exists action. The policy helps add/delete bins in
+  records without replacing existing data."
+  [client new-expiration]
+  (let [wp (write-policy client new-expiration)]
+    (set! (.recordExistsAction wp) RecordExistsAction/UPDATE_ONLY)
+    wp))
+
 (defn ^EventPolicy map->event-policy
   "Create an `EventPolicy` from a map. Usage same as `map->write-policy`."
   [conf]

--- a/src/aerospike_clj/utils.clj
+++ b/src/aerospike_clj/utils.clj
@@ -33,13 +33,13 @@
   however, `true`, `false` or `nil` exist as the only value in a bin, they need to
   be sanitized."
   [bin-value]
-  (->> (conj [] bin-value)
+  (->> (vector bin-value)
        (replace (set/map-invert boolean-replacements))
        first))
 
 (defn desanitize-bin-value
   "Converts sanitized (keywordized) bin values back to their original value."
   [bin-value]
-  (->> (conj [] bin-value)
+  (->> (vector bin-value)
        (replace boolean-replacements)
        first))

--- a/src/aerospike_clj/utils.clj
+++ b/src/aerospike_clj/utils.clj
@@ -18,28 +18,39 @@
   not accepted. The conversion happens only at the top-level of the bin and does not
   seem to affect nested structures. To store these values in the database, they are
   converted to keywords."
-  {:true  true
-   :false false
-   :nil   nil})
+  {true  :true
+   false :false
+   nil   :nil})
 
+;; transducers
+(def ^:private x-sanitize
+  (replace boolean-replacements))
+
+(def ^:private x-desanitize
+  (replace (set/map-invert boolean-replacements)))
+
+;; predicates
 (defn single-bin?
   "Predicate function to determine whether data will be stored as a single bin or
   multiple bin record."
   [bin-names]
   (= bin-names [""]))
 
+(defn string-keys?
+  "Predicate function to determine whether all keys provided for bins are strings."
+  [bin-names]
+  (every? string? bin-names))
+
 (defn sanitize-bin-value
   "Values in nested structures are unaffected and do not need to be sanitized. If,
   however, `true`, `false` or `nil` exist as the only value in a bin, they need to
   be sanitized."
   [bin-value]
-  (->> (vector bin-value)
-       (replace (set/map-invert boolean-replacements))
+  (->> (into [] x-sanitize (vector bin-value))
        first))
 
 (defn desanitize-bin-value
   "Converts sanitized (keywordized) bin values back to their original value."
   [bin-value]
-  (->> (vector bin-value)
-       (replace boolean-replacements)
+  (->> (into [] x-desanitize (vector bin-value))
        first))

--- a/src/aerospike_clj/utils.clj
+++ b/src/aerospike_clj/utils.clj
@@ -22,6 +22,12 @@
    :false false
    :nil   nil})
 
+(defn single-bin?
+  "Predicate function to determine whether data will be stored as a single bin or
+  multiple bin record."
+  [bin-names]
+  (= bin-names [""]))
+
 (defn sanitize-bin-value
   "Values in nested structures are unaffected and do not need to be sanitized. If,
   however, `true`, `false` or `nil` exist as the only value in a bin, they need to

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -66,10 +66,10 @@
 (deftest put-get-clj-map
   (let [data {"foo" {"bar" [(rand-int 1000)]}}]
     (is (true? @(client/create *c* K _set data 100)))
-    (testing "clojure maps can be serialized as-is")
-    (let [v @(client/get-single-no-meta *c* K _set)]
-      (is (= data v)) ;; per value it is identical
-      (is (= clojure.lang.PersistentArrayMap (type v))))))
+    (testing "clojure maps can be serialized as-is"
+      (let [v @(client/get-single-no-meta *c* K _set)]
+        (is (= data v)) ;; per value it is identical
+        (is (= clojure.lang.PersistentArrayMap (type v)))))))
 
 (deftest put-multiple-bins-get-clj-map
   (let [data {"foo" {"bar" [(rand-int 1000)]}

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -112,7 +112,7 @@
     (testing "bin values can be added to existing records"
       (let [v @(client/get-single-no-meta *c* K _set)]
         (is (= v (merge data new-data)))
-        (is (= (contains? v "qux")))))
+        (is (= (into #{} (keys v)) #{"foo" "bar" "baz" "qux"}))))
     (testing "adding a bin that already exists in the record with a new value"
       (let [existing-bin {"foo" [(rand-int 1000)]}]
         (is (true? @(client/add-bins *c* K _set existing-bin 100)))

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -101,16 +101,16 @@
               :bar [(rand-int 1000)]
               :baz [(rand-int 1000)]}]
     (is (true? @(client/create *c* K _set data 100)))
-    (testing "bin values can be retrieved individually and all together")
-    (let [v1 @(client/get-single *c* K _set [:foo])
-          v2 @(client/get-single *c* K _set [:bar])
-          v3 @(client/get-single *c* K _set [:baz])
-          v4 @(client/get-single *c* K _set [:all])]
-      (is (= (:foo data) (:foo (:payload v1))))
-      (is (= (:bar data) (:bar (:payload v2))))
-      (is (= (:baz data) (:baz (:payload v3))))
-      (is (= data (:payload v4)))
-      (is (true? (map? (:payload v1)))))))
+    (testing "bin values can be retrieved individually and all together"
+      (let [v1 @(client/get-single *c* K _set [:foo])
+            v2 @(client/get-single *c* K _set [:bar])
+            v3 @(client/get-single *c* K _set [:baz])
+            v4 @(client/get-single *c* K _set [:all])]
+        (is (= (:foo data) (:foo (:payload v1))))
+        (is (= (:bar data) (:bar (:payload v2))))
+        (is (= (:baz data) (:baz (:payload v3))))
+        (is (= data (:payload v4)))
+        (is (true? (map? (:payload v1))))))))
 
 (deftest adding-bins-to-record
   (let [data {:foo [(rand-int 1000)]
@@ -119,10 +119,10 @@
         new-data {:qux [(rand-int 1000)]}]
     (is (true? @(client/create *c* K _set data 100)))
     (is (true? @(client/add-bins *c* K _set new-data 100))) ;; adding value to bin
-    (testing "bin values can be added to existing records")
-    (let [v @(client/get-single-no-meta *c* K _set)]
-      (is (= v (merge data new-data)))
-      (is (contains? v :qux)))))
+    (testing "bin values can be added to existing records"
+      (let [v @(client/get-single-no-meta *c* K _set)]
+        (is (= v (merge data new-data)))
+        (is (contains? v :qux))))))
 
 (deftest removing-bins-from-record
   (let [data {:foo [(rand-int 1000)]
@@ -132,10 +132,10 @@
         bin-keys [:foo :bar :baz]]
     (is (true? @(client/create *c* K _set data 100)))
     (is (true? @(client/delete-bins *c* K _set bin-keys 100))) ;; removing value from bin
-    (testing "bin values can be removed from existing records")
-    (let [v @(client/get-single-no-meta *c* K _set)]
-      (is (= v (apply dissoc data bin-keys)))
-      (is (contains? v :qux)))))
+    (testing "bin values can be removed from existing records"
+      (let [v @(client/get-single-no-meta *c* K _set)]
+        (is (= v (apply dissoc data bin-keys)))
+        (is (contains? v :qux))))))
 
 (deftest update-test
   (is (true? @(client/create *c* K _set 16 100)))

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -77,14 +77,14 @@
               "qux" false
               "quuz" nil}]
     (is (true? @(client/create *c* K _set data 100)))
-    (testing "clojure maps can be serialized from bins")
-    (let [v @(client/get-single-no-meta *c* K _set)]
-      (is (= (get data "foo") (get v "foo"))) ;; per value it is identical
-      (is (= (get data "bar") (get v "bar"))) ;; true value returns the same after being sanitized/desanitized
-      (is (= (get data "baz") (get v "baz"))) ;; false value returns the same after being sanitized/desanitized
-      (is (= (get data "qux") (get v "qux"))) ;; nil value retuns the same after being sanitized/desanitized
-      (is (= clojure.lang.PersistentArrayMap (type v))) ;; converted back to a Clojure map instead of HashMap
-      (is (true? (map? v))))))
+    (testing "clojure maps can be serialized from bins"
+      (let [v @(client/get-single-no-meta *c* K _set)]
+        (is (= (get data "foo") (get v "foo"))) ;; per value it is identical
+        (is (= (get data "bar") (get v "bar"))) ;; true value returns the same after being sanitized/desanitized
+        (is (= (get data "baz") (get v "baz"))) ;; false value returns the same after being sanitized/desanitized
+        (is (= (get data "qux") (get v "qux"))) ;; nil value retuns the same after being sanitized/desanitized
+        (is (= clojure.lang.PersistentArrayMap (type v))) ;; converted back to a Clojure map instead of HashMap
+        (is (true? (map? v)))))))
 
 (deftest get-single-multiple-bins
   (let [data {"foo"  [(rand-int 1000)]
@@ -95,7 +95,7 @@
       (let [v1 @(client/get-single *c* K _set {} ["foo"])
             v2 @(client/get-single *c* K _set {} ["bar"])
             v3 @(client/get-single *c* K _set {} ["baz"])
-            v4 @(client/get-single *c* K _set {} [:all])]
+            v4 @(client/get-single *c* K _set {})] ;; getting all bins for the record
         (is (= (get data "foo") (get (:payload v1) "foo")))
         (is (= (get data "bar") (get (:payload v2) "bar")))
         (is (= (get data "baz") (get (:payload v3) "baz")))
@@ -228,7 +228,7 @@
 (deftest transcoder-failure
   (is (true? @(client/create *c* K _set 1 100)))
   (let [transcoder (fn [_] (throw (Exception. "oh-no")))]
-    (is (thrown-with-msg? Exception #"oh-no" @(client/get-single *c* K _set {:transcoder transcoder} [:all])))))
+    (is (thrown-with-msg? Exception #"oh-no" @(client/get-single *c* K _set {:transcoder transcoder})))))
 
 (deftest operations-lists
   (let [result1 @(client/operate *c* K _set 100
@@ -316,7 +316,7 @@
             (letfn [(->set [res] (->> ^HashMap (:payload res)
                                       .keySet
                                       (into #{})))]
-              @(client/get-single *c* K _set {:transcoder ->set} [:all])))
+              @(client/get-single *c* K _set {:transcoder ->set})))
           (set-size []
             (client/operate *c* K _set 100
                             [(MapOperation/size "")]))]
@@ -348,7 +348,7 @@
                                ListReturnType/VALUE)]))
           (set-getall []
             (letfn [(->set [res] (->> res :payload (into #{})))]
-              @(client/get-single *c* K _set {:transcoder ->set} [:all])))
+              @(client/get-single *c* K _set {:transcoder ->set})))
           (set-size []
             (client/operate *c* K _set 100
                             [(ListOperation/size "")]))]

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -69,22 +69,21 @@
     (testing "clojure maps can be serialized as-is")
     (let [v @(client/get-single-no-meta *c* K _set)]
       (is (= data v)) ;; per value it is identical
-      (is (= java.util.HashMap (type v))) ;; but we get back a HashMap
-      (is (false? (map? v)))
+      (is (= clojure.lang.PersistentArrayMap (type v)))
       (testing "using Jackson to recursively create a PersistantHashMap"
         (let [json (.writeValueAsString (ObjectMapper.) v)
               parsed (json/parse-string json #(keyword (subs % 1)))]
           (is (= data parsed))
           (is (true? (map? parsed))))))))
 
-(deftest put-bins-get-clj-map
+(deftest put-multiple-bins-get-clj-map
   (let [data {:foo {:bar [(rand-int 1000)]}
               :baz true
               :qux false
               :quux nil}]
-    (is (true? @(client/create-with-bins *c* K _set data 100)))
+    (is (true? @(client/create *c* K _set data 100)))
     (testing "clojure maps can be serialized from bins")
-    (let [v @(client/get-single-all-bins-no-meta *c* K _set)]
+    (let [v @(client/get-single-no-meta *c* K _set)]
       (is (= (:foo data) (:foo v))) ;; per value it is identical
       (is (= (:baz data) (:baz v))) ;; true value returns the same after being sanitized/desanitized
       (is (= (:qux data) (:qux v))) ;; false value returns the same after being sanitized/desanitized
@@ -97,16 +96,16 @@
           (is (= data parsed))
           (is (true? (map? parsed))))))))
 
-(deftest get-single-bins
+(deftest get-single-multiple-bins
   (let [data {:foo [(rand-int 1000)]
               :bar [(rand-int 1000)]
               :baz [(rand-int 1000)]}]
-    (is (true? @(client/create-with-bins *c* K _set data 100)))
+    (is (true? @(client/create *c* K _set data 100)))
     (testing "bin values can be retrieved individually and all together")
-    (let [v1 @(client/get-single-with-bins *c* K _set [:foo])
-          v2 @(client/get-single-with-bins *c* K _set [:bar])
-          v3 @(client/get-single-with-bins *c* K _set [:baz])
-          v4 @(client/get-single-with-bins *c* K _set [:all])]
+    (let [v1 @(client/get-single *c* K _set [:foo])
+          v2 @(client/get-single *c* K _set [:bar])
+          v3 @(client/get-single *c* K _set [:baz])
+          v4 @(client/get-single *c* K _set [:all])]
       (is (= (:foo data) (:foo (:payload v1))))
       (is (= (:bar data) (:bar (:payload v2))))
       (is (= (:baz data) (:baz (:payload v3))))
@@ -118,10 +117,10 @@
               :bar [(rand-int 1000)]
               :baz [(rand-int 1000)]}
         new-data {:qux [(rand-int 1000)]}]
-    (is (true? @(client/create-with-bins *c* K _set data 100)))
-    (is (true? @(client/add-bins-to-record *c* K _set new-data 100))) ;; adding value to bin
+    (is (true? @(client/create *c* K _set data 100)))
+    (is (true? @(client/add-bins *c* K _set new-data 100))) ;; adding value to bin
     (testing "bin values can be added to existing records")
-    (let [v @(client/get-single-all-bins-no-meta *c* K _set)]
+    (let [v @(client/get-single-no-meta *c* K _set)]
       (is (= v (merge data new-data)))
       (is (contains? v :qux)))))
 
@@ -131,10 +130,10 @@
               :baz [(rand-int 1000)]
               :qux [(rand-int 1000)]}
         bin-keys [:foo :bar :baz]]
-    (is (true? @(client/create-with-bins *c* K _set data 100)))
-    (is (true? @(client/remove-bins-from-record *c* K _set bin-keys 100))) ;; removing value from bin
+    (is (true? @(client/create *c* K _set data 100)))
+    (is (true? @(client/delete-bins *c* K _set bin-keys 100))) ;; removing value from bin
     (testing "bin values can be removed from existing records")
-    (let [v @(client/get-single-all-bins-no-meta *c* K _set)]
+    (let [v @(client/get-single-no-meta *c* K _set)]
       (is (= v (apply dissoc data bin-keys)))
       (is (contains? v :qux)))))
 
@@ -154,7 +153,7 @@
   (let [long-bin-name "thisstringislongerthan14characters"]
     (is (thrown-with-msg?
           Exception #"Bin names have to be <= 14 characters..."
-          @(client/put-with-bins *c* K _set {long-bin-name "foo"} 100)))))
+          @(client/put *c* K _set {long-bin-name "foo"} 100)))))
 
 (deftest update-with-wrong-gen
   (let [data (rand-int 1000)]
@@ -234,7 +233,7 @@
 (deftest transcoder-failure
   (is (true? @(client/create *c* K _set 1 100)))
   (let [transcoder (fn [_] (throw (Exception. "oh-no")))]
-    (is (thrown-with-msg? Exception #"oh-no" @(client/get-single *c* K _set {:transcoder transcoder})))))
+    (is (thrown-with-msg? Exception #"oh-no" @(client/get-single *c* K _set [:all] {:transcoder transcoder})))))
 
 (deftest operations-lists
   (let [result1 @(client/operate *c* K _set 100
@@ -322,7 +321,7 @@
             (letfn [(->set [res] (->> ^HashMap (:payload res)
                                       .keySet
                                       (into #{})))]
-              @(client/get-single *c* K _set {:transcoder ->set})))
+              @(client/get-single *c* K _set [:all] {:transcoder ->set})))
           (set-size []
             (client/operate *c* K _set 100
                             [(MapOperation/size "")]))]
@@ -354,7 +353,7 @@
                                ListReturnType/VALUE)]))
           (set-getall []
             (letfn [(->set [res] (->> res :payload (into #{})))]
-              @(client/get-single *c* K _set {:transcoder ->set})))
+              @(client/get-single *c* K _set [:all] {:transcoder ->set})))
           (set-size []
             (client/operate *c* K _set 100
                             [(ListOperation/size "")]))]


### PR DESCRIPTION
Hello folks are AppsFlyer,

Thanks for creating this library. It introduced me to Aerospike and got me to play around with it.

I was considering using it for a project and wanted to create secondary indices which require data to be stored as `bins` within `records`. 

This PR introduces `bin` creation via Clojure maps. Each key-value pair in the map is converted to a `bin` and stored in a `record`. There were some issues with `true`, `false` and `nil` values being stored at the top level for a `bin`. I have provided a solution for storing these values in the database and getting them back as they were. Aerospike's documentation suggests setting `bin` values to _null_ to remove them from the database but I did not want to go down that path. 

I have also added the ability to modify stored records by adding or removing `bins`. The current solution does not have a `generation` argument that your single `bin` update function has. That may be something that you want to provide guidance on.

Please let me what other changes you would like made to this PR. Once it is in a state that you are happy with, I would like to contribute by adding a new `query.clj` namespace that would have the following functionality:

- create/drop secondary index
- querying `records` by `bins`
 
Thanks again!
- Drew