### PR TITLE
Added db scanning capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /codox
 .eastwood
 .clj-kondo
+aerospike-clj.iml
+.idea/
+/.lein-failures
+target
+.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "0.3.6"
+(defproject aerospike-clj "0.3.7"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -22,10 +22,6 @@
 
 (def MAX_BIN_NAME_LENGTH 14)
 
-(def
-  ^{:const true :doc "Constant used to abort a scan operation"}
-  ABORT-SCAN "ABORT-SCAN")
-
 (defprotocol IAerospikeClient
   (^AerospikeClient get-client [ac] [ac index] "Returns the relevant AerospikeClient object for the specific shard")
   (get-all-clients [_] "Returns a sequence of all AerospikeClient objects."))
@@ -130,7 +126,7 @@
 (defn- ^RecordSequenceListener reify-record-sequence-listener [op-future callback]
   (reify RecordSequenceListener
     (^void onRecord [_this ^Key k ^Record record]
-      (when (= ABORT-SCAN (callback (.userKey k) (record->map record)))
+      (when (= :abort-scan (callback (.userKey k) (record->map record)))
         (throw (AerospikeException$QueryTerminated.))))
     (^void onSuccess [_this]
       (d/success! op-future true))
@@ -483,7 +479,7 @@
 (defn scan-set
   "Scans through the given set and calls a user defined callback for each record that was found.
   Returns a deferred response that resolves once the scan completes. When the scan completes
-  successfully it returns `true`. The scan may be aborted by returning `ABORT-SCAN` from the callback.
+  successfully it returns `true`. The scan may be aborted by returning :abort-scan from the callback.
   In that case the return value is `false`.
 
   The `conf` argument should be a map with the following keys:

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -8,7 +8,7 @@
             [aerospike-clj.policy :as policy]
             [cheshire.core :as json]
             [taoensso.timbre :refer [spy]])
-  (:import [com.aerospike.client AerospikeException Value]
+  (:import [com.aerospike.client AerospikeException Value AerospikeClient]
            [com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
                                      MapOperation MapPolicy MapOrder MapWriteFlags MapReturnType CTX]
            [com.aerospike.client.policy Priority ReadModeSC ReadModeAP Replica GenerationPolicy RecordExistsAction
@@ -454,7 +454,7 @@
     (is (= #{"bar"} (set-getall)))))
 
 (deftest default-read-policy
-  (let [rp (.getReadPolicyDefault (client/get-client *c*))]
+  (let [rp (.getReadPolicyDefault ^AerospikeClient (client/get-client *c*))]
     (is (= Priority/DEFAULT (.priority rp))) ;; Priority of request relative to other transactions. Currently, only used for scans.
     (is (= ReadModeAP/ONE (.readModeAP rp))) ;; Involve single node in the read operation.
     (is (= Replica/SEQUENCE (.replica rp))) ;; Try node containing master partition first.

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -625,7 +625,7 @@
                                                              {:index K3 :set _set}])))))
       (delete-records))
 
-    (testing "it should stop the scan when the callback returns `ABORT-SCAN`"
+    (testing "it should stop the scan when the callback returns :abort-scan"
       @(client/put-multiple *c* [K K2 K3] (repeat _set) [10 20 30] (repeat ttl) conf)
 
       (let [res (atom [])
@@ -633,7 +633,7 @@
             callback (fn [k v]
                        (if (< (swap! counter inc) 2)
                          (swap! res conj [(.toString ^Value k) (:payload v)])
-                         client/ABORT-SCAN))]
+                         :abort-scan))]
 
         (is (false? @(client/scan-set *c* aero-namespace _set {:callback callback})))
         (is (= 1 (count @res))))


### PR DESCRIPTION
Added a new feature that is available in the Aerospike java client - the ability to retrieve or perform operations on all the records in a set.
Some use cases: 
- Iterating over the records in a set and pushing them to a queue for processing, or to another data store.
- Collecting all the records and returning them.
- Programmatically and selectively performing different operations on records.

The implementation exposes the functionality of `public final void scanAll(EventLoop eventLoop, RecordSequenceListener listener, ScanPolicy policy, String namespace, String setName, String... binNames) throws AerospikeException` from `com.aerospike.client`.
  
The function is documented, and the tests show what you can and cannot do.

On a side note, I know it says not to mix other changes with the PR. But a few slipped in:
- Added some common files to .gitignore
- Added type hints where the compiler was complaining.
- Fixed one typo
