### PR TITLE
Mock client

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ $ sudo docker run -d --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 
 $ lein test
 ```
 
+#### Mocking in application unit tests
+When performing unit tests in application code, it is most times undesirable to launch a full aerospike container to 
+run tests again. For those cases the library exposes a mock client that once initialized in a test mocks all the calls 
+to `aerospike-clj.client`.  
+
+Usage:
+
+```clojure
+(ns com-example.app 
+  (:require [clojure.test :refer [deftest use-fixtures]]
+            [aerospike-clj.mock-client :refer [init-mock]]))
+
+(use-fixtures :each init-mock)
+
+(deftest ...) ;; define your application unit tests as usual
+```
+
+The sample code executes on every test run. It initializes the mock and runs
+the test within a `with-redefs` - rebinding all the calls to functions
+in `aerospike-clj.client` to the mock.
+
+Note: If the production client is initiated using a state management framework,
+you would also need to stop and restart the state on each test run.
+
+
 ## Contributing
 PRs are welcome!
 

--- a/src/aerospike_clj/mock_client.clj
+++ b/src/aerospike_clj/mock_client.clj
@@ -1,0 +1,296 @@
+(ns aerospike-clj.mock-client
+  (:refer-clojure :exclude [update])
+  (:require [aerospike-clj.client :as client]
+            [aerospike-clj.utils]
+            [manifold.deferred :as defer]
+            [clojure.pprint :refer [pprint]])
+  (:import (clojure.lang IPersistentVector IPersistentMap)
+           (com.aerospike.client AerospikeException ResultCode)))
+
+
+(defprotocol AerospikeClient
+  (get-single [this k set-name]
+    [this k set-name conf]
+    [this k set-name conf bin-names])
+  (get-multiple [this indices sets]
+    [this indices sets conf])
+  (exists? [this k set-name]
+    [this k set-name conf])
+  (get-single-no-meta [this k set-name]
+    [this k set-name ^IPersistentVector bin-names])
+  (put [this k set-name data expiration]
+    [this k set-name data expiration conf])
+  (add-bins [this k set-name ^IPersistentMap new-data new-expiration]
+    [this k set-name ^IPersistentMap new-data new-expiration conf])
+  (put-multiple [this indices set-names payloads expiration-seq]
+    [this indices set-names payloads expiration-seq conf])
+  (create [this k set-name data expiration]
+    [this k set-name data expiration conf])
+  (replace-only [this k set-name data expiration]
+    [this k set-name data expiration conf])
+  (update [this k set-name new-record generation new-expiration]
+    [this k set-name new-record generation new-expiration conf])
+  (set-single [this k set-name data expiration]
+    [this k set-name data expiration conf])
+  (touch [this k set-name expiration])
+  (delete [this k set-name]
+    [this k set-name conf])
+  (delete-bins [this k set-name ^IPersistentVector bin-names new-expiration]
+    [this k set-name ^IPersistentVector bin-names new-expiration conf])
+  (operate [this k set-name expiration operations]
+    [this k set-name expiration operations conf])
+  (get-cluster-stats [this])
+  (healthy? [this operation-timeout-ms])
+  (stop-aerospike-client [this])
+  (get-state [this] [this set-name])
+  (print-state [this]))
+
+
+
+(def ^:private DEFAULT_SET "__DEFAULT__")
+
+(defn- get-set-name [set-name]
+  (if (some? set-name) set-name DEFAULT_SET))
+
+(defn- get-record [state set-name k]
+  (get-in state [(get-set-name set-name) k]))
+
+(defn- set-record [state value set-name k]
+  (assoc-in state [(get-set-name set-name) k] value))
+
+(defn- delete-record [state set-name k]
+  (clojure.core/update state (get-set-name set-name) dissoc k))
+
+(defn record-exists? [state set-name k]
+  (some? (get-record state (get-set-name set-name) k)))
+
+(defn- get-generation
+  "The number of times the record has been modified.
+  Defaults to 0 if the record doesn't exist or the value cannot be determined."
+  [state set-name k]
+  (:gen (get-record state set-name k) 0))
+
+(defn- get-transcoder [conf]
+  (:transcoder conf identity))
+
+(defn- create-record
+  ([payload ttl] (create-record payload ttl 1))
+  ([payload ttl generation]
+   {:payload payload :ttl ttl :gen generation}))
+
+(defn- do-swap [state swap-fn]
+  (try
+    (do
+      (swap! state swap-fn)
+      (defer/success-deferred true))
+    (catch AerospikeException ex
+      (defer/error-deferred ex))))
+
+
+(defrecord MockClient [state]
+  AerospikeClient
+  (get-single [this k set-name] (get-single this k set-name {} nil))
+
+  (get-single [this k set-name conf] (get-single this k set-name conf nil))
+
+  (get-single [_ k set-name conf _]
+    (let [transcoder (get-transcoder conf)]
+      (defer/success-deferred (transcoder (get-record @state set-name k)))))
+
+  (get-multiple [this indices set-names]
+    (get-multiple this indices set-names {}))
+
+  (get-multiple [this indices set-names conf]
+    (defer/success-deferred
+      (mapv (fn [k set-name] @(get-single this k set-name conf)) indices set-names)))
+
+  (get-single-no-meta [this k set-name]
+    (get-single this k set-name {:transcoder :payload}))
+
+  (get-single-no-meta [this k set-name bin-names]
+    (get-single this k set-name {:transcoder :payload} bin-names))
+
+  (exists? [this k set-name]
+    (exists? this k set-name {}))
+
+  (exists? [_ k set-name _]
+    (defer/success-deferred (record-exists? @state set-name k)))
+
+  (put [this k set-name data expiration]
+    (put this k set-name data expiration {}))
+
+  (put [_ k set-name data expiration conf]
+    (let [transcoder (get-transcoder conf)
+          new-record (create-record (transcoder data) expiration)
+          swap-fn (fn [current-state] (set-record current-state new-record set-name k))]
+      (do-swap state swap-fn)))
+
+  (set-single [this k set-name data expiration]
+    (set-single this k set-name data expiration {}))
+
+  (set-single [this k set-name data expiration conf]
+    (let [generation (get-generation @state set-name k)]
+      (update this k set-name data generation expiration conf)))
+
+  (add-bins [this k set-name new-data new-expiration]
+    (add-bins this k set-name new-data new-expiration {}))
+
+  (add-bins [_ k set-name new-data new-expiration conf]
+    (let [transcoder (get-transcoder conf)
+          swap-fn (fn [current-state]
+                    (if-let [old-data (:payload (get-record current-state set-name k))]
+                      (let [merged-data (merge old-data new-data)
+                            generation (get-generation current-state set-name k)
+                            new-record (create-record
+                                         (transcoder merged-data) new-expiration generation)]
+                        (set-record current-state new-record set-name k))
+                      (throw (AerospikeException.
+                               (ResultCode/KEY_NOT_FOUND_ERROR)
+                               (str "Call to `add-bins` on non-existing key '" k "'")))))]
+      (do-swap state swap-fn)))
+
+  (put-multiple [this indices set-names payloads expiration-seq]
+    (put-multiple this indices set-names payloads expiration-seq {}))
+
+  (put-multiple [this indices set-names payloads expiration-seq conf]
+    (defer/success-deferred
+      (mapv (fn [k set-name payload expiration]
+              @(put this k set-name payload expiration conf))
+            indices set-names payloads expiration-seq)))
+
+  (create [this k set-name data expiration]
+    (create this k set-name data expiration {}))
+
+  (create [_ k set-name data expiration conf]
+    (let [swap-fn (fn [current-state]
+                    (when (some? (get-record current-state set-name k))
+                      (throw (AerospikeException.
+                               (ResultCode/KEY_EXISTS_ERROR)
+                               (str "Call to `create` on existing key '" k "'"))))
+
+                    (let [transcoder (get-transcoder conf)
+                          new-record (create-record (transcoder data) expiration)]
+                      (set-record current-state new-record set-name k)))]
+      (do-swap state swap-fn)))
+
+  (replace-only [this k set-name data expiration]
+    (replace-only this k set-name data expiration {}))
+
+  (replace-only [_ k set-name data expiration conf]
+    (let [swap-fn (fn [current-state]
+                    (if (some? (get-record current-state set-name k))
+                      (let [transcoder (get-transcoder conf)
+                            new-record (create-record (transcoder data) expiration)]
+                        (set-record current-state new-record set-name k))
+                      (AerospikeException.
+                        ResultCode/KEY_NOT_FOUND_ERROR
+                        (str "Call to `replace-only` on non-existing key '" k "'"))))]
+      (do-swap state swap-fn)))
+
+  (update [this k set-name new-record generation new-expiration]
+    (update this k set-name new-record generation new-expiration {}))
+
+  (update [_ k set-name new-record expected-generation new-expiration conf]
+    (let [swap-fn (fn [current-state]
+                    (let [current-generation (get-generation current-state set-name k)]
+                      (when-not (= current-generation expected-generation)
+                        (throw (AerospikeException.
+                                 (ResultCode/GENERATION_ERROR)
+                                 (str "Record 'generation' count does not match expected value: '"
+                                      expected-generation "'"))))
+
+                      (let [transcoder (get-transcoder conf)
+                            new-record (create-record
+                                         (transcoder new-record) new-expiration (inc current-generation))]
+                        (set-record current-state new-record set-name k))))]
+      (do-swap state swap-fn)))
+
+  (touch [_ k set-name expiration]
+    (let [swap-fn (fn [current-state]
+                    (if-let [record (get-record current-state set-name k)]
+                      (let [new-record (assoc record :ttl expiration)]
+                        (set-record current-state new-record set-name k))
+                      (throw (AerospikeException.
+                               ResultCode/KEY_NOT_FOUND_ERROR
+                               (str "Call to `touch` on non-existing key '" k "'")))))]
+      (do-swap state swap-fn)))
+
+  (delete [_ k set-name]
+    (let [success? (atom nil)
+          swap-fn (fn [current-state]
+                    (if (record-exists? current-state set-name k)
+                      (do
+                        (reset! success? true)
+                        (delete-record current-state set-name k))
+                      (do
+                        (reset! success? false)
+                        current-state)))]
+      (do-swap state swap-fn)
+      (defer/success-deferred @success?)))
+
+  (delete-bins [this k set-name bin-names new-expiration]
+    (delete-bins this k set-name bin-names new-expiration {}))
+
+  (delete-bins [_ k set-name bin-names new-expiration _]
+    (let [swap-fn (fn [current-state]
+                    (if-let [old-data (:payload (get-record current-state set-name k))]
+                      (let [merged-data (apply dissoc old-data bin-names)
+                            generation (get-generation current-state set-name k)
+                            new-record (create-record merged-data new-expiration generation)]
+                        (set-record current-state new-record set-name k))
+                      (throw (AerospikeException.
+                               (ResultCode/KEY_NOT_FOUND_ERROR)
+                               (str "Call to `delete-bins` on non-existing key '" k "'")))))]
+      (do-swap state swap-fn)))
+
+  (operate [this k set-name expiration operations]
+    (operate this k set-name expiration operations nil))
+
+  (operate [_ _ _ _ _ _]
+    (throw (RuntimeException. "Function not implemented")))
+
+  (healthy? [_ _] true)
+
+  (get-cluster-stats [_] [[]])
+
+  (stop-aerospike-client [_]
+    (reset! state {DEFAULT_SET {}}))
+
+  (get-state [this]
+    (get-state this DEFAULT_SET))
+
+  (get-state [_ set-name]
+    (get @state set-name))
+
+  (print-state [_]
+    (pprint @state)))
+
+(defn expiry-unix [ttl]
+  (client/expiry-unix ttl))
+
+(defn create-instance [& _]
+  (MockClient. (atom {DEFAULT_SET {}})))
+
+(defn init-mock [test-fn]
+  (with-redefs
+    [client/init-simple-aerospike-client create-instance
+     client/stop-aerospike-client stop-aerospike-client
+     client/get-single get-single
+     client/get-multiple get-multiple
+     client/exists? exists?
+     client/get-single-no-meta get-single-no-meta
+     client/put put
+     client/add-bins add-bins
+     client/put-multiple put-multiple
+     client/create create
+     client/replace-only replace-only
+     client/update update
+     client/set-single set-single
+     client/touch touch
+     client/delete delete
+     client/delete-bins delete-bins
+     client/operate operate
+     client/get-cluster-stats get-cluster-stats
+     client/healthy? healthy?
+     client/expiry-unix expiry-unix]
+    (test-fn)))

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -1,0 +1,271 @@
+(ns aerospike-clj.mock-client-test
+  (:refer-clojure :exclude [update])
+  (:require [clojure.test :refer :all]
+            [aerospike-clj.mock-client :as mock]
+            [aerospike-clj.client :as client])
+  (:import [com.aerospike.client ResultCode AerospikeException]))
+
+(def ^:dynamic ^mock/AerospikeClient client nil)
+
+(defn- rebind-client-to-mock [test-fn]
+  (binding [client (mock/create-instance)]
+    (test-fn)))
+
+(use-fixtures :each rebind-client-to-mock)
+
+(deftest get-single-test
+  (mock/put client "foo" "my-set" {:bar 20} 86400)
+
+  (testing "it should return a deferrable of a single record if it exists"
+    (let [expected {:payload {:bar 20} :ttl 86400 :gen 1}
+          actual (mock/get-single client "foo" "my-set")]
+      (is (= @actual expected))))
+
+  (testing "it should return a deferrable of nil if it doesn't exist"
+    (let [actual (mock/get-single client "foo" nil)]
+      (is (= @actual nil)))
+    (let [actual (mock/get-single client "does-not-exist" "my-set")]
+      (is (= @actual nil)))))
+
+(deftest get-single-no-meta-test
+  (mock/put client "foo" nil "bar" 30)
+
+  (testing "it should return a deferrable of a single record without metadata if it exists"
+    (let [expected "bar"
+          actual (mock/get-single-no-meta client "foo" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should return a deferrable of nil if it doesn't exist"
+    (let [actual (mock/get-single-no-meta client "does-not-exist" nil)]
+      (is (= @actual nil)))))
+
+(deftest get-multiple-test
+  (testing "it should return a deferrable of vector of matched records"
+    (mock/put-multiple client ["foo" "bar"] [nil "some-set"] ["is best" "is better"] [86400 43200])
+
+    (let [expected [{:payload "is best" :ttl 86400 :gen 1}]
+          actual (mock/get-multiple client ["foo"] [nil])]
+      (is (= @actual expected)))
+
+    (let [expected [{:payload "is better" :ttl 43200 :gen 1}]
+          actual (mock/get-multiple client ["bar"] ["some-set"])]
+      (is (= @actual expected)))
+
+    (let [expected [{:payload "is best" :ttl 86400 :gen 1}
+                    {:payload "is better" :ttl 43200 :gen 1}]
+          actual (mock/get-multiple client ["foo" "bar"] [nil "some-set"])]
+      (is (= @actual expected)))
+
+    (let [expected [nil nil]
+          actual (mock/get-multiple client ["does-not-exist" "also-not-here"] [nil "some-set"])]
+      (is (= @actual expected)))))
+
+(deftest exists?-test
+  (testing "it should return a deferrable of boolean indicating whether a record exists"
+    (mock/put client "foo" nil "bar" 30)
+    (is (= @(mock/exists? client "foo" nil) true))
+    (is (= @(mock/exists? client "bar" nil) false))
+    (is (= @(mock/exists? client "FOO" nil) false))
+    (is (= @(mock/exists? client "" nil) false))
+    (is (= @(mock/exists? client nil nil) false))))
+
+(deftest put-test
+  (testing "it should create a new record if it doesn't exist"
+    (mock/put client "foo" nil "bar" 30)
+    (let [expected {:payload "bar" :ttl 30 :gen 1}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should replace a record if it exists"
+    (mock/put client "foo" nil "bar" 30)
+    (let [expected {:payload "bar" :ttl 30 :gen 1}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected)))
+
+    (mock/put client "foo" nil "baz" 40)
+    (let [expected {:payload "baz" :ttl 40 :gen 1}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected)))))
+
+(deftest set-single-test
+  (testing "it should create a new record if it doesn't exist"
+    (mock/set-single client "foo" nil "bar" 30)
+    (let [expected {:payload "bar" :ttl 30 :gen 1}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should update a record if it exists"
+    (mock/set-single client "foo" nil "baz" 30)
+    (let [expected {:payload "baz" :ttl 30 :gen 2}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected)))
+
+    (mock/set-single client "foo" nil "baz" 40)
+    (let [expected {:payload "baz" :ttl 40 :gen 3}
+          actual (mock/get-single client "foo" nil)]
+      (is (= @actual expected)))))
+
+(deftest put-multiple-test
+  (testing "it should create a new record for each one that doesn't exist and replace each one
+  that does"
+    (let [put-result (mock/put-multiple client ["foo" "bar"] [nil nil] [1 2] [60 60])
+          expected [{:payload 1 :ttl 60 :gen 1}
+                    {:payload 2 :ttl 60 :gen 1}]
+          actual (mock/get-multiple client ["foo" "bar"] [nil nil])]
+      (is (= @put-result [true true]))
+      (is (= @actual expected)))
+
+
+    (let [put-result (mock/put-multiple client ["foo" "baz"] [nil nil] [3 4] [120 60])
+          expected [{:payload 3 :ttl 120 :gen 1}
+                    {:payload 2 :ttl 60 :gen 1}
+                    {:payload 4 :ttl 60 :gen 1}]
+          actual (mock/get-multiple client ["foo" "bar" "baz"] [nil nil nil])]
+      (is (= @put-result [true true]))
+      (is (= @actual expected)))))
+
+(deftest add-bins-test
+  (testing "it should add bins to an existing record without modifying old data"
+    (mock/set-single client "person" nil {:fname "John" :lname "Baker"} 30)
+    (mock/add-bins client "person" nil {:prefix "Mr."} 60)
+
+    (let [expected {:payload {:fname "John" :lname "Baker" :prefix "Mr."} :ttl 60 :gen 1}
+          actual (mock/get-single client "person" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should throw an exception if key doesn't exist"
+    (try
+      (do
+        @(mock/add-bins client "does-not-exist" nil {:prefix "Mr."} 60)
+        (throw (AssertionError. "Expected AerospikeException to be thrown in `add-bins-test`")))
+      (catch AerospikeException ex
+        (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
+
+(deftest create-test
+  (testing "it should create a new record"
+    (mock/create client "foo" "set1" "bar" 60)
+    (mock/create client "baz" nil {:value 1} 30)
+
+    (let [expected {:payload "bar" :ttl 60 :gen 1}
+          actual (mock/get-single client "foo" "set1")]
+      (is (= @actual expected)))
+
+    (let [expected {:payload {:value 1} :ttl 30 :gen 1}
+          actual (mock/get-single client "baz" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should throw an exception when a key already exists"
+    (doseq [args [["key1" "set1" "val1" 60] ["key2" nil "val2" 60]]]
+      (apply mock/create client args)
+      (try
+        (do
+          @(apply mock/create client args)
+          (throw (AssertionError.
+                   (str "Expected AerospikeException to be thrown in `create-test`: " args))))
+        (catch AerospikeException ex
+          (is (= (.getResultCode ex) ResultCode/KEY_EXISTS_ERROR)))))))
+
+(deftest touch-test
+  (testing "it should update the record's ttl if it exists"
+    (mock/create client "foo" "set1" "bar" 60)
+    (mock/touch client "foo" "set1" 10)
+
+    (let [expected {:payload "bar" :ttl 10 :gen 1}
+          actual (mock/get-single client "foo" "set1")]
+      (is (= @actual expected))))
+
+  (testing "it should throw an exception if a key doesn't exist"
+    (try
+      (do
+        @(mock/touch client "does-not-exist" nil 120)
+        (throw (AssertionError. "Expected AerospikeException to be thrown in `touch-test`")))
+      (catch AerospikeException ex
+        (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
+
+(deftest delete-test
+  (testing "it should delete a record if it exists"
+    (mock/create client "foo" "set1" "bar" 60)
+    (is (= @(mock/delete client "foo" "set1") true))
+    (is (= @(mock/get-single client "foo" "set1") nil))
+
+    (mock/create client "foo" nil "bar" 30)
+    (is (= @(mock/delete client "foo" nil) true))
+    (is (= @(mock/get-single client "foo" nil) nil)))
+
+  (testing "it should return false if a key doesn't exist"
+    (mock/create client "foo" nil "bar" 60)
+    (mock/create client "foo" "set1" "bar" 60)
+    (let [default-set (mock/get-state client)
+          set1 (mock/get-state client "set1")]
+      (is (= @(mock/delete client "does-not-exist" nil) false))
+      (is (= @(mock/delete client "does-not-exist" "foo-bar") false))
+
+      (is (= default-set (mock/get-state client)))
+      (is (= set1 (mock/get-state client "set1"))))))
+
+(deftest delete-bins-test
+  (testing "it should delete the given bins in an existing record without modifying others"
+    (mock/create client "person" nil {:fname "John" :lname "Baker" :prefix "Mr." :age 74} 30)
+    (mock/delete-bins client "person" nil [:prefix :age] 60)
+
+    (let [expected {:payload {:fname "John" :lname "Baker"} :ttl 60 :gen 1}
+          actual (mock/get-single client "person" nil)]
+      (is (= @actual expected)))
+
+    (mock/delete-bins client "person" nil [:prefix :age] 10)
+    (let [expected {:payload {:fname "John" :lname "Baker"} :ttl 10 :gen 1}
+          actual (mock/get-single client "person" nil)]
+      (is (= @actual expected))))
+
+  (testing "it should throw an exception if key doesn't exist"
+    (try
+      (do
+        @(mock/delete-bins client "does-not-exist" nil [:fname] 60)
+        (throw (AssertionError. "Expected AerospikeException to be thrown in `delete-bins-test`")))
+      (catch AerospikeException ex
+        (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
+
+(deftest expiry-unix-test
+  (testing "it should proxy to aerospike-clj"
+    (is (= (mock/expiry-unix 100) (client/expiry-unix 100)))))
+
+(deftest operate-test
+  (testing "function is not implemented"
+    (try
+      (do
+        (mock/operate client "foo" nil 120 [])
+        (throw (AssertionError. "Expected RuntimeException to be thrown in `operate-test`")))
+      (catch RuntimeException _
+        (is (= 1 1))))))
+
+(deftest healthy-test
+  (is (= (mock/healthy? client 0) true)))
+
+(deftest get-cluster-stats-test
+  (is (= [[]] (mock/get-cluster-stats client))))
+
+(deftest apply-transcoder-test
+  (testing "it should apply the transcoder function to the payload before inserting it"
+    (let [conf {:transcoder #(clojure.core/update % :bar inc)}
+          expected {:payload {:bar 21} :ttl 86400 :gen 1}]
+
+      (mock/put client "foo" "my-set" {:bar 20} 86400 conf)
+      (is (= @(mock/get-single client "foo" "my-set") expected))))
+
+  (testing "it should apply the transcoder function to the whole record before returning it"
+    (let [conf {:transcoder #(clojure.core/update-in % [:payload :bar] inc)}
+          expected {:payload {:bar 22} :ttl 86400 :gen 1}
+          actual (mock/get-single client "foo" "my-set" conf)]
+      (is (= @actual expected))))
+
+  (testing "it should apply the transcoder function on each record before returning them"
+    (mock/put-multiple client ["a" "b" "c"] [nil nil nil] ["d" "e" "f"] [10 20 30])
+
+    (let [upper-case-value #(clojure.core/update % :payload clojure.string/upper-case)
+          increment-ttl #(clojure.core/update % :ttl inc)
+          conf {:transcoder (comp increment-ttl upper-case-value)}
+          expected [{:payload "D" :ttl 11 :gen 1}
+                    {:payload "E" :ttl 21 :gen 1}
+                    {:payload "F" :ttl 31 :gen 1}]
+          actual @(mock/get-multiple client ["a" "b" "c"] [nil nil nil] conf)]
+      (is (= actual expected)))))


### PR DESCRIPTION
Added a mock Aerospike client that can be used in application unit tests where you don't want to launch a local Aerospike container or connect to a remote instance.

The mock implements all public functions that are exposed in [aerospike-clj.client](https://github.com/AppsFlyer/aerospike-clj/blob/2d2d531035c8064da3f9c83cad8510a242335186/src/aerospike_clj/client.clj). From a user perspective all they need to do is add [aerospike-clj.mock-client/init-mock](https://github.com/AppsFlyer/aerospike-clj/blob/2d2d531035c8064da3f9c83cad8510a242335186/test/aerospike_clj/mock_client_test.clj) as a fixture on each test run.

Updated [README.md](https://github.com/AppsFlyer/aerospike-clj/blob/2d2d531035c8064da3f9c83cad8510a242335186/README.md) with usage example.

**Note**: The branch is forked from `db-scan` branch, so it should be merged after [PR 23](https://github.com/AppsFlyer/aerospike-clj/pull/23) 