### PR TITLE
Support more key creation options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "0.4.1"
+(defproject aerospike-clj "0.5.0"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -160,14 +160,14 @@
     (^void onSuccess [_this ^List records]
       (d/success! op-future records))))
 
-(defprotocol CreateKey
+(defprotocol UserKey
   "Use `create-key` directly to pass a premade custom key to the public API.
-  When passing a simple String/Integher/Long/ByteArray the key will be created
+  When passing a simple String/Integer/Long/ByteArray the key will be created
   automatically for you. If you pass a ready made key, `as-namespace` and 
   `set-name` are ignored in API calls."
   (create-key ^Key [this as-namespace set-name]))
 
-(extend-protocol CreateKey
+(extend-protocol UserKey
   Key
   (create-key ^Key [this _ _]
     this)

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -3,6 +3,7 @@
   (:require [aerospike-clj.policy :as policy]
             [aerospike-clj.utils :as utils]
             [aerospike-clj.metrics :as metrics]
+            [aerospike-clj.key :as as-key]
             [manifold.deferred :as d])
   (:import [com.aerospike.client AerospikeClient Host Key Bin Record AerospikeException Operation BatchRead AerospikeException$QueryTerminated]
            [com.aerospike.client.async EventLoop NioEventLoops]
@@ -20,7 +21,6 @@
   ^{:doc "The 0 date reference for returned record TTL"}
   (.getEpochSecond (Instant/parse "2010-01-01T00:00:00Z")))
 
-(def MAX_KEY_LENGTH (dec (bit-shift-left 1 13)))
 
 (def MAX_BIN_NAME_LENGTH 14)
 
@@ -160,11 +160,21 @@
     (^void onSuccess [_this ^List records]
       (d/success! op-future records))))
 
-(defn- ^Key create-key [^String aero-namespace ^String set-name ^String k]
-  (when (< MAX_KEY_LENGTH (.length k))
-    (throw (Exception. (format "key is too long: %s..." (subs k 0 40)))))
-  (Key. aero-namespace set-name k))
+(defprotocol CreateKey
+  "Use `create-key` directly to pass a premade custom key to the public API.
+  When passing a simple String/Integher/Long/ByteArray the key will be created
+  automatically for you. If you pass a ready made key, `as-namespace` and 
+  `set-name` are ignored in API calls."
+  (create-key ^Key [this as-namespace set-name]))
 
+(extend-protocol CreateKey
+  Key
+  (create-key ^Key [this _ _]
+    this)
+  Object
+  (create-key ^Key [this as-namespace set-name]
+    (as-key/create-key this as-namespace set-name)))
+  
 (defn- ^Bin create-bin [^String bin-name bin-value]
   (when (< MAX_BIN_NAME_LENGTH (.length bin-name))
     (throw (Exception. (format "%s is %s characters. Bin names have to be <= 14 characters..." bin-name (.length bin-name)))))
@@ -231,13 +241,13 @@
             ^EventLoop (.next ^NioEventLoops (:el db))
             (reify-record-listener op-future)
             ^Policy (:policy conf)
-            (create-key (:dbns db) set-name index))
+            (create-key index (:dbns db) set-name))
       ;; For all other cases, bin-names are passed to a different `get` method
       (.get ^AerospikeClient client
             ^EventLoop (.next ^NioEventLoops (:el db))
             (reify-record-listener op-future)
             ^Policy (:policy conf)
-            (create-key (:dbns db) set-name index)
+            (create-key index (:dbns db) set-name)
             ^"[Ljava.lang.String;" (utils/v->array String bin-names)))
     (let [d (d/chain' op-future
                       record->map
@@ -252,7 +262,7 @@
   ([db index set-name conf bin-names] (_get db index set-name conf bin-names)))
 
 (defn- ^BatchRead map->batch-read [batch-read-map dbns]
-  (let [k (create-key dbns (:set batch-read-map) (:index batch-read-map))]
+  (let [k (create-key (:index batch-read-map) dbns (:set batch-read-map))]
     (if (or (= [:all] (:bins batch-read-map))
             (nil? (:bins batch-read-map)))
       (BatchRead. k true)
@@ -306,7 +316,7 @@
               ^EventLoop (.next ^NioEventLoops (:el db))
               (reify-exists-listener op-future)
               ^Policy (:policy conf)
-              (create-key (:dbns db) set-name index))
+              (create-key index (:dbns db) set-name))
      (register-events op-future db "exists" index start-time))))
 
 (defn get-single-no-meta
@@ -325,7 +335,7 @@
           ^EventLoop (.next ^NioEventLoops (:el db))
           ^WriteListener (reify-write-listener op-future)
           ^WritePolicy policy
-          (create-key (:dbns db) set-name index)
+          (create-key index (:dbns db) set-name)
           ^"[Lcom.aerospike.client.Bin;" bins)
     (register-events op-future db "write" index start-time)))
 
@@ -426,7 +436,7 @@
             ^EventLoop (.next ^NioEventLoops (:el db))
             ^WriteListener (reify-write-listener op-future)
             ^WritePolicy (policy/write-policy client expiration RecordExistsAction/UPDATE_ONLY)
-            (create-key (:dbns db) set-name index))
+            (create-key index (:dbns db) set-name))
     (register-events op-future db "touch" index start-time)))
 
 ;; delete
@@ -444,7 +454,7 @@
               ^EventLoop (.next ^NioEventLoops (:el db))
               ^DeleteListener (reify-delete-listener op-future)
               ^WritePolicy (:policy conf)
-              (create-key (:dbns db) set-name index))
+              (create-key index (:dbns db) set-name))
      (register-events op-future db "delete" index start-time))))
 
 (defn- _delete-bins [db index bin-names policy set-name]
@@ -455,7 +465,7 @@
           ^EventLoop (.next ^NioEventLoops (:el db))
           ^WriteListener (reify-write-listener op-future)
           ^WritePolicy policy
-          (create-key (:dbns db) set-name index)
+          (create-key index (:dbns db) set-name)
           ^"[Lcom.aerospike.client.Bin;" (utils/v->array Bin (mapv set-bin-as-null bin-names)))
     (register-events op-future db "write" index start-time)))
 
@@ -489,7 +499,7 @@
                  ^EventLoop (.next ^NioEventLoops (:el db))
                  ^RecordListener (reify-record-listener op-future)
                  ^WritePolicy (:policy conf (policy/write-policy client expiration RecordExistsAction/UPDATE))
-                 (create-key (:dbns db) set-name index)
+                 (create-key index (:dbns db) set-name)
                  (utils/v->array Operation operations))
        (register-events (d/chain' op-future record->map) db "operate" index start-time)))))
 

--- a/src/aerospike_clj/key.clj
+++ b/src/aerospike_clj/key.clj
@@ -6,14 +6,14 @@
   (create-key-method ^Key [this ^String as-namesapce ^String set-name]))
 
 (extend-protocol AerospikeIndex
-  (Class/forName "[B") 
+  (Class/forName "[B") ;; byte-array 
   (create-key-method ^Key [this ^String as-namesapce ^String set-name]
-    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (alength #^bytes this) (.length set-name)))
+    (when (<= (ThreadLocalData/DefaultBufferSize) (+ (alength #^bytes this) (.length set-name)))
       (throw (Exception. (format "key is too long: %s..." this))))
     (Key. ^String as-namesapce ^String set-name #^bytes this))
   String 
   (create-key-method ^Key [this ^String as-namesapce ^String set-name]
-    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (.length this) (.length set-name)))
+    (when (<= (ThreadLocalData/DefaultBufferSize) (+ (.length this) (.length set-name)))
       (throw (Exception. (format "key is too long: %s..." (subs this 0 40)))))
     (Key. as-namesapce set-name this))
   Integer 
@@ -24,7 +24,7 @@
     (Key. as-namesapce set-name (.longValue this)))
   Value 
   (create-key-method ^Key [this ^String as-namesapce ^String set-name]
-    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (.estimateSize this) (.length set-name)))
+    (when (<= (ThreadLocalData/DefaultBufferSize) (+ (.estimateSize this) (.length set-name)))
       (throw (Exception. (format "key is too long: %s..." (subs (.toString this) 0 40)))))
     (Key. as-namesapce set-name this)))
 

--- a/src/aerospike_clj/key.clj
+++ b/src/aerospike_clj/key.clj
@@ -1,0 +1,37 @@
+(ns aerospike-clj.key
+  (:import [com.aerospike.client Key Value]
+           [com.aerospike.client.util ThreadLocalData]))
+
+(defprotocol AerospikeIndex
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]))
+
+(extend-protocol AerospikeIndex
+  (Class/forName "[B") 
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]
+    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (alength #^bytes this) (.length set-name)))
+      (throw (Exception. (format "key is too long: %s..." this))))
+    (Key. ^String as-namesapce ^String set-name #^bytes this))
+  String 
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]
+    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (.length this) (.length set-name)))
+      (throw (Exception. (format "key is too long: %s..." (subs this 0 40)))))
+    (Key. as-namesapce set-name this))
+  Integer 
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]
+    (Key. as-namesapce set-name (.longValue this)))
+  Long 
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]
+    (Key. as-namesapce set-name (.longValue this)))
+  Value 
+  (create-key-method ^Key [this ^String as-namesapce ^String set-name]
+    (when (< (ThreadLocalData/DefaultBufferSize) (+ 1 (.estimateSize this) (.length set-name)))
+      (throw (Exception. (format "key is too long: %s..." (subs (.toString this) 0 40)))))
+    (Key. as-namesapce set-name this)))
+
+(defn create-key
+  "Create an aerospike key. It is recommended to create simple keys (without 
+  precomputed digest) with `client/create-key`"
+  (^Key [k ^String as-namesapce ^String set-name]
+   (create-key-method k as-namesapce set-name))
+  (^Key [#^bytes digest ^String as-namesapce ^String set-name ^Value user-key]
+   (Key. as-namesapce digest set-name user-key)))

--- a/src/aerospike_clj/key.clj
+++ b/src/aerospike_clj/key.clj
@@ -34,4 +34,6 @@
   (^Key [k ^String as-namesapce ^String set-name]
    (create-key-method k as-namesapce set-name))
   (^Key [#^bytes digest ^String as-namesapce ^String set-name ^Value user-key]
+    (when (not= 20 (alength digest))
+      (throw (Exception. "digest has to exactly 20 bytes long")))
    (Key. as-namesapce digest set-name user-key)))

--- a/test/aerospike_clj/key_test.clj
+++ b/test/aerospike_clj/key_test.clj
@@ -1,0 +1,57 @@
+(ns aerospike-clj.key-test
+  (:require [aerospike-clj.key :refer [create-key]]
+            [clojure.test :refer [deftest is]]
+            [taoensso.timbre :refer [spy]]
+            [clojure.string :as s])
+  (:import [com.aerospike.client Key Value]
+           [com.aerospike.client.util ThreadLocalData]))
+
+(defn- compare-keys 
+  ([_k1] true)
+  ([k1 k2] (= (spy (seq (.digest ^Key k1)))
+              (spy (seq (.digest ^Key k2)))))
+  ([^Key k1 ^Key k2 & more]
+   (if (= (seq (.digest ^Key k1))
+          (seq (.digest ^Key k2)))
+     (if (next more)
+       (recur k2 (first more) (next more))
+       (compare-keys k2 (first more)))
+     false)))
+      
+(deftest create-with-digest
+  (let [as-ns "ns"
+        as-set "set"
+        as-key "key" 
+        k (create-key as-key as-ns as-set)
+        k-digest (.digest k)]
+    (is (.equals k 
+                 (create-key k-digest as-ns as-set (Value/get "user-key"))))))
+
+(deftest create-with-digest-and-byte-array
+  (let [as-ns "ns"
+        as-set "set"
+        ba (byte-array 10)]
+      (doseq [i (range 10)]
+        (aset-byte ba i i))
+      (let [k (create-key ba as-ns as-set nil)
+            k-digest (.digest k)]
+        (is (.equals k 
+                     (create-key k-digest as-ns as-set nil))))))
+
+(deftest create-with-numbers
+  (let [as-ns "ns"
+        as-set "set"]
+    (is (.equals (create-key 1000 as-ns as-set)
+                 (create-key (int 1000) as-ns as-set)))))
+
+(deftest too-long-key
+  (let [too-long-key (s/join "" (repeat (ThreadLocalData/DefaultBufferSize) "k"))
+        too-long-ba (byte-array (ThreadLocalData/DefaultBufferSize))
+        too-long-value (Value/get (byte-array (ThreadLocalData/DefaultBufferSize)))]
+    (is (thrown-with-msg? Exception #"key is too long"
+                          (create-key too-long-key "ns" "set")))
+    (is (thrown-with-msg? Exception #"key is too long"
+                          (create-key too-long-ba "ns" "set")))
+    (is (thrown-with-msg? Exception #"key is too long"
+                          (create-key too-long-value "ns" "set")))))
+

--- a/test/aerospike_clj/key_test.clj
+++ b/test/aerospike_clj/key_test.clj
@@ -30,8 +30,8 @@
 (deftest create-with-digest-and-byte-array
   (let [as-ns "ns"
         as-set "set"
-        ba (byte-array 10)]
-      (doseq [i (range 10)]
+        ba (byte-array 20)]
+      (doseq [i (range 20)]
         (aset-byte ba i i))
       (let [k (create-key ba as-ns as-set nil)
             k-digest (.digest k)]
@@ -53,5 +53,7 @@
     (is (thrown-with-msg? Exception #"key is too long"
                           (create-key too-long-ba "ns" "set")))
     (is (thrown-with-msg? Exception #"key is too long"
-                          (create-key too-long-value "ns" "set")))))
+                          (create-key too-long-value "ns" "set")))
+    (is (thrown-with-msg? Exception #"digest has to exactly 20 bytes long"
+                          (create-key (byte-array 19) "ns" "set" nil)))))
 


### PR DESCRIPTION
- `create-key` is now public and polymorphic and all
  APIs accept a premade key, in addition to other types that can be used for keys.
- convenient key creation has moved into the `key` namespace
  and allow creating keys from a pre-computed digest, byte-
  array, Integer, Long and String.