### PR TITLE
Support for batch exists calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### VERSION 0.5.0
+* Added mocking for aerospike client
+
 #### VERSION 0.3.8
 * Bump aerospike lib to 4.4.9
 
@@ -9,7 +12,7 @@
 
 #### VERSION 0.3.5
 * Bump aerospike lib to 4.4.4.
-* Improve CDT tests (requires testing agains aerospike server v4.6)
+* Improve CDT tests (requires testing against aerospike server v4.6)
 
 #### VERSION 0.3.4
 * Rename set to set-single. liraz.meyer@appsflyer.com

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ $ lein test
 
 #### Mocking in application unit tests
 When performing unit tests in application code, it is most times undesirable to launch a full aerospike container to 
-run tests again. For those cases the library exposes a mock client that once initialized in a test mocks all the calls 
-to `aerospike-clj.client`.  
+run tests against. For those cases the library exposes a mock client that replaces all the calls to `aerospike-clj.client`.  
 
 Usage:
 

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -308,14 +308,15 @@
    (let [client (get-client db)
          op-future (d/deferred)
          start-time (System/nanoTime)
-         indices (utils/v->array Key (mapv #(create-key (:index %) (:dbns db) (:set %)) indices))]
+         aero-namespace (:dbns db)
+         indices (utils/v->array Key (mapv #(create-key (:index %) aero-namespace (:set %)) indices))]
      (.exists ^AerospikeClient client
               ^EventLoop (.next ^NioEventLoops (:el db))
               (reify-exists-array-listener op-future)
               ^BatchPolicy (:policy conf)
               ^"[Lcom.aerospike.client.Key;" indices)
      (let [d (d/chain' op-future
-                       #(vec %)
+                       vec
                        (:transcoder conf identity))]
        (register-events d db "read-batch" nil start-time)))))
 

--- a/src/aerospike_clj/mock_client.clj
+++ b/src/aerospike_clj/mock_client.clj
@@ -12,7 +12,8 @@
   (get-single [this k set-name]
     [this k set-name conf]
     [this k set-name conf bin-names])
-  (get-multiple [this indices sets]
+  (get-multiple ^{:deprecated "0.3.2"}
+    [this indices sets]
     [this indices sets conf])
   (get-batch [this batch-reads]
     [this batch-reads conf])

--- a/src/aerospike_clj/mock_client.clj
+++ b/src/aerospike_clj/mock_client.clj
@@ -322,6 +322,7 @@
      client/get-single get-single
      client/get-multiple get-multiple
      client/exists? exists?
+     client/exists-batch exists-batch
      client/get-single-no-meta get-single-no-meta
      client/put put
      client/add-bins add-bins

--- a/src/aerospike_clj/mock_client.clj
+++ b/src/aerospike_clj/mock_client.clj
@@ -81,9 +81,8 @@
 
 (defn- do-swap [state swap-fn]
   (try
-    (do
-      (swap! state swap-fn)
-      (defer/success-deferred true))
+    (swap! state swap-fn)
+    (defer/success-deferred true)
     (catch AerospikeException ex
       (defer/error-deferred ex))))
 

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -114,6 +114,18 @@
       (is (= [data data2 nil data3 nil] (mapv :payload res)))
       (is (= [1 1 nil 1 nil] (mapv :gen res))))))
 
+(deftest exists-batch
+  (is (true? @(client/create *c* K _set 1 100)))
+  (is (true? @(client/create *c* K2 _set2 1 100)))
+  (is (true? @(client/create *c* K3 _set 1 100)))
+  (let [indices [{:index K2 :set _set}
+                 {:index K2 :set _set2}
+                 {:index K3 :set _set}
+                 {:index K :set _set}
+                 {:index K_not_exists :set _set}]
+        res @(client/exists-batch *c* indices)]
+    (is (= [false true true true false] res))))
+
 (deftest put-get-clj-map
   (let [data {"foo" {"bar" [(rand-int 1000)]}}]
     (is (true? @(client/create *c* K _set data 100)))
@@ -580,7 +592,7 @@
 (deftest scan-test
   (let [conf {:policy (policy/map->write-policy {"sendKey" true})}
         aero-namespace "test"
-        ttl 100
+        ttl 10
         delete-records (fn []
                          @(client/delete *c* K _set)
                          @(client/delete *c* K2 _set)

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -1,8 +1,9 @@
 (ns aerospike-clj.mock-client-test
   (:refer-clojure :exclude [update])
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [aerospike-clj.mock-client :as mock]
-            [aerospike-clj.client :as client])
+            [aerospike-clj.client :as client]
+            [clojure.string])
   (:import [com.aerospike.client ResultCode AerospikeException]))
 
 (def ^:dynamic ^mock/AerospikeClient client nil)
@@ -135,9 +136,8 @@
 
   (testing "it should throw an exception if key doesn't exist"
     (try
-      (do
-        @(mock/add-bins client "does-not-exist" nil {"prefix" "Mr."} 60)
-        (throw (AssertionError. "Expected AerospikeException to be thrown in `add-bins-test`")))
+      @(mock/add-bins client "does-not-exist" nil {"prefix" "Mr."} 60)
+      (throw (AssertionError. "Expected AerospikeException to be thrown in `add-bins-test`"))
       (catch AerospikeException ex
         (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
 
@@ -158,10 +158,9 @@
     (doseq [args [["key1" "set1" "val1" 60] ["key2" nil "val2" 60]]]
       (apply mock/create client args)
       (try
-        (do
-          @(apply mock/create client args)
-          (throw (AssertionError.
-                   (str "Expected AerospikeException to be thrown in `create-test`: " args))))
+        @(apply mock/create client args)
+        (throw (AssertionError.
+                 (str "Expected AerospikeException to be thrown in `create-test`: " args)))
         (catch AerospikeException ex
           (is (= (.getResultCode ex) ResultCode/KEY_EXISTS_ERROR)))))))
 
@@ -176,9 +175,8 @@
 
   (testing "it should throw an exception if a key doesn't exist"
     (try
-      (do
-        @(mock/touch client "does-not-exist" nil 120)
-        (throw (AssertionError. "Expected AerospikeException to be thrown in `touch-test`")))
+      @(mock/touch client "does-not-exist" nil 120)
+      (throw (AssertionError. "Expected AerospikeException to be thrown in `touch-test`"))
       (catch AerospikeException ex
         (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
 
@@ -219,9 +217,8 @@
 
   (testing "it should throw an exception if key doesn't exist"
     (try
-      (do
-        @(mock/delete-bins client "does-not-exist" nil ["fname"] 60)
-        (throw (AssertionError. "Expected AerospikeException to be thrown in `delete-bins-test`")))
+      @(mock/delete-bins client "does-not-exist" nil ["fname"] 60)
+      (throw (AssertionError. "Expected AerospikeException to be thrown in `delete-bins-test`"))
       (catch AerospikeException ex
         (is (= (.getResultCode ex) ResultCode/KEY_NOT_FOUND_ERROR))))))
 
@@ -232,9 +229,8 @@
 (deftest operate-test
   (testing "function is not implemented"
     (try
-      (do
-        (mock/operate client "foo" nil 120 [])
-        (throw (AssertionError. "Expected RuntimeException to be thrown in `operate-test`")))
+      (mock/operate client "foo" nil 120 [])
+      (throw (AssertionError. "Expected RuntimeException to be thrown in `operate-test`"))
       (catch RuntimeException _
         (is (= 1 1))))))
 

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -61,14 +61,56 @@
           actual (mock/get-multiple client ["does-not-exist" "also-not-here"] [nil "some-set"])]
       (is (= @actual expected)))))
 
+(deftest get-batch-test
+  (testing "it should return a deferrable of vector of matched records"
+    (mock/put-multiple client
+                       ["foo" "bar" "fuzz"]
+                       [nil "some-set" "some-set"]
+                       ["is best" "is better" {"rank" "not so good" "solution" "give up"}]
+                       [86400 43200 10])
+
+    (let [expected [{:payload "is best" :ttl 86400 :gen 1} nil]
+          actual (mock/get-batch client [{:index "foo" :set nil} {:index "bar" :set "bar"}])]
+      (is (= @actual expected)))
+
+    (let [expected [{:payload "is better" :ttl 43200 :gen 1} nil {:payload {"rank" "not so good"} :ttl 10 :gen 1}]
+          actual (mock/get-batch client [{:index "bar" :set "some-set"} {:index "bar" :set nil} {:index "fuzz" :set "some-set" :bins ["rank"]}])]
+      (is (= @actual expected)))))
+
 (deftest exists?-test
   (testing "it should return a deferrable of boolean indicating whether a record exists"
     (mock/put client "foo" nil "bar" 30)
-    (is (= @(mock/exists? client "foo" nil) true))
-    (is (= @(mock/exists? client "bar" nil) false))
-    (is (= @(mock/exists? client "FOO" nil) false))
-    (is (= @(mock/exists? client "" nil) false))
-    (is (= @(mock/exists? client nil nil) false))))
+    (is (true? @(mock/exists? client "foo" nil)))
+    (is (false? @(mock/exists? client "bar" nil)))
+    (is (false? @(mock/exists? client "FOO" nil)))
+    (is (false? @(mock/exists? client "" nil)))
+    (is (false? @(mock/exists? client nil nil)))))
+
+(deftest exists-batch-test
+  (testing "it should return a deferrable vector of booleans indicating whether each key exists"
+    (mock/put-multiple client
+                       ["foo" "fuzz" "bar" "baz"]
+                       ["set1" "set2" "set1" "set3"]
+                       [1 1 1 1]
+                       [30 30 30 30])
+
+    (is (= @(mock/exists-batch client [{:index "foo" :set "set1"}
+                                       {:index "fuzz" :set "set2"}
+                                       {:index "bar" :set "set1"}
+                                       {:index "baz" :set "set3"}])
+           [true true true true]))
+
+    (is (= @(mock/exists-batch client [{:index "foo" :set "set1"}
+                                       {:index "fuzz" :set "set1"}
+                                       {:index "bar" :set "set1"}
+                                       {:index "baz" :set "set1"}])
+           [true false true false]))
+
+    (is (= @(mock/exists-batch client [{:index "zoo" :set "set1"}
+                                       {:index "fizz" :set "set1"}
+                                       {:index "vec" :set "set1"}
+                                       {:index "pez" :set "set1"}])
+           [false false false false]))))
 
 (deftest put-test
   (testing "it should create a new record if it doesn't exist"


### PR DESCRIPTION
Similar to `batch-get` only returns booleans rather than the actual records.
Also added missing `batch-get` function to the mock.