### PR TITLE
fix flaky tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "0.5.2"
+(defproject aerospike-clj "0.5.3"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -16,5 +16,6 @@
                                   [criterium "0.4.5"]
                                   [cheshire "5.10.0"]
                                   [com.taoensso/timbre "4.10.0"]
+                                  [danlentz/clj-uuid "0.1.9"]
                                   [com.fasterxml.jackson.core/jackson-databind "2.10.2"]]
                    :global-vars {*warn-on-reflection* true}}})

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -8,11 +8,9 @@
             [aerospike-clj.policy :as policy]
             [aerospike-clj.key :as as-key]
             [cheshire.core :as json]
-            [manifold.deferred :as d]
-            [taoensso.timbre :refer [spy]]
-            [clojure.data.codec.base64 :as b64])
+            [manifold.deferred :as d])
   (:import [com.aerospike.client AerospikeException Value AerospikeClient 
-            AerospikeException$AsyncQueueFull Key]
+            AerospikeException$AsyncQueueFull]
            [com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
                                      MapOperation MapPolicy MapOrder MapWriteFlags MapReturnType CTX]
            [com.aerospike.client.policy Priority ReadModeSC ReadModeAP Replica GenerationPolicy RecordExistsAction

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -8,9 +8,8 @@
             [aerospike-clj.policy :as policy]
             [aerospike-clj.key :as as-key]
             [cheshire.core :as json]
-            [manifold.deferred :as d])
-  (:import [com.aerospike.client AerospikeException Value AerospikeClient 
-            AerospikeException$AsyncQueueFull]
+            [clj-uuid :as uuid])
+  (:import [com.aerospike.client AerospikeException Value AerospikeClient] 
            [com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
                                      MapOperation MapPolicy MapOrder MapWriteFlags MapReturnType CTX]
            [com.aerospike.client.policy Priority ReadModeSC ReadModeAP Replica GenerationPolicy RecordExistsAction
@@ -50,7 +49,7 @@
   (is (true? (client/healthy? *c* 10))))
 
 (defn random-key [] 
-  (str (rand-int Integer/MAX_VALUE)))
+  (str (uuid/v4)))
 
 (deftest get-record
   (let [data (rand-int 1000)


### PR DESCRIPTION
3 facts combined made the test randomly fail:

1. the tests used constant keys,
2. the AS client only removes keys from index (RAM) first, and only later from disk.
4. tests sometimes use different overlapping clients on the same disk volume.

This makes clients see each other records during scans.
To fix that all keys made random per-test.
Tests using scans were made aware
that other keys may be on the DB while they run.
Remove explicit keys cleanup before each test.
unrelated- reduced the use of deprecated `get-multiple`.

- Another option to fix this was using durable-deletes but these only available in the EE.