### PR TITLE
Added "exists-batch" operation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "0.5.3"
+(defproject aerospike-clj "0.5.4"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/src/aerospike_clj/client.clj
+++ b/src/aerospike_clj/client.clj
@@ -318,7 +318,7 @@
      (let [d (d/chain' op-future
                        vec
                        (:transcoder conf identity))]
-       (register-events d db "read-batch" nil start-time)))))
+       (register-events d db "exists-batch" nil start-time)))))
 
 (defn get-multiple
   "DEPRECATED - use `get-batch` instead.


### PR DESCRIPTION
Adding the name allows for specific metrics on batch `exists` requests.