### PR TITLE
1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## This library follows [Semantic Versioning](https://semver.org).
 ## This CHANGELOG follows [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
-### VERSION 1.1.0
+### VERSION 1.0.3
 #### Updated:
-* Bumped `com.aerospike/aerospike-client` to `5.1.5.1`. This is a special version available in Maven Central without any
-  official release notes. Functionally it's the same as `5.1.5` without the requirement of using server version `4.9` and
-  above. This version lacks the `com.aerospike.client.policy.Priority` enum, so it was removed from this library.
+* Bumped `com.aerospike/aerospike-client` to `4.4.18`.
+* Bumped `funcool/promesa` to `6.0.2`.
+
+#### Changed:
+* Using a different method from `com.aerospike.client.Host` to parse a hosts strings
+  that contains TLS names for seed nodes in order to allow connecting to a TLS-enabled
+  cluster.
 
 ### VERSION 1.0.2
 #### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## This library follows [Semantic Versioning](https://semver.org).
 ## This CHANGELOG follows [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
+### VERSION 1.1.0
+#### Updated:
+* Bumped `com.aerospike/aerospike-client` to `5.1.5.1`. This is a special version available in Maven Central without any
+  official release notes. Functionally it's the same as `5.1.5` without the requirement of using server version `4.9` and
+  above. This version lacks the `com.aerospike.client.policy.Priority` enum, so it was removed from this library.
+
 ### VERSION 1.0.2
 #### Added:
 * This CHANGELOG now follows [keepachangelog](https://keepachangelog.com/en/1.0.0/).

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "1.1.0"
+(defproject aerospike-clj "1.0.3"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"
@@ -13,8 +13,8 @@
                                       :username      :env/clojars_username
                                       :password      :env/clojars_password
                                       :sign-releases false}]]
-  :dependencies [[com.aerospike/aerospike-client "5.1.5.1"]
-                 [funcool/promesa "5.1.0"]]
+  :dependencies [[com.aerospike/aerospike-client "4.4.18"]
+                 [funcool/promesa "6.0.2"]]
   :profiles {:dev  {:plugins      [[jonase/eastwood "0.3.5"]
                                    [lein-ancient "0.6.15"]
                                    [lein-eftest "0.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject aerospike-clj "1.0.2"
+(defproject aerospike-clj "1.1.0"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"
@@ -13,7 +13,7 @@
                                       :username      :env/clojars_username
                                       :password      :env/clojars_password
                                       :sign-releases false}]]
-  :dependencies [[com.aerospike/aerospike-client "4.4.15"]
+  :dependencies [[com.aerospike/aerospike-client "5.1.5.1"]
                  [funcool/promesa "5.1.0"]]
   :profiles {:dev  {:plugins      [[jonase/eastwood "0.3.5"]
                                    [lein-ancient "0.6.15"]

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -47,8 +47,9 @@
   ([host client-policy]
    (create-client host client-policy 3000))
   ([hosts client-policy port]
-   (let [hosts-arr (into-array Host (for [h hosts]
-                                      ^Host (Host. h port)))]
+   (let [hosts-str (str (apply str (interpose (format ":%d," port) hosts))
+                        (format ":%d" port))
+         hosts-arr (Host/parseHosts hosts-str port)]
      (AerospikeClient. ^ClientPolicy client-policy ^"[Lcom.aerospike.client.Host;" hosts-arr))))
 
 (defn create-event-loops

--- a/src/main/clojure/aerospike_clj/policy.clj
+++ b/src/main/clojure/aerospike_clj/policy.clj
@@ -2,8 +2,7 @@
   (:import [com.aerospike.client AerospikeClient]
            [com.aerospike.client.async EventPolicy]
            [com.aerospike.client.policy Policy ClientPolicy WritePolicy RecordExistsAction 
-            GenerationPolicy BatchPolicy CommitLevel AuthMode ReadModeAP ReadModeSC 
-            Priority Replica]))
+            GenerationPolicy BatchPolicy CommitLevel AuthMode ReadModeAP ReadModeSC Replica]))
 
 (defmacro set-java [obj conf obj-name]
   `(when (some? (get ~conf ~obj-name))
@@ -29,7 +28,6 @@
       (set-java-enum p conf "ReadModeAP")
       (set-java-enum p conf "ReadModeSC")
       (set-java p conf "maxRetries")
-      (set-java-enum p conf "Priority")
       (set-java-enum p conf "Replica")
       (set-java p conf "sendKey")
       (set-java p conf "sleepBetweenRetries")

--- a/test/aerospike_clj/client_test.clj
+++ b/test/aerospike_clj/client_test.clj
@@ -12,7 +12,7 @@
   (:import [com.aerospike.client Value AerospikeClient]
            [com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
                                      MapOperation MapPolicy MapOrder MapWriteFlags MapReturnType CTX]
-           [com.aerospike.client.policy Priority ReadModeSC ReadModeAP Replica GenerationPolicy RecordExistsAction
+           [com.aerospike.client.policy ReadModeSC ReadModeAP Replica GenerationPolicy RecordExistsAction
                                         WritePolicy BatchPolicy Policy]
            [java.util HashMap ArrayList]
            [java.util.concurrent ExecutionException]
@@ -547,7 +547,6 @@
 
 (deftest default-read-policy
   (let [rp (.getReadPolicyDefault ^AerospikeClient (client/get-client *c*))]
-    (is (= Priority/DEFAULT (.priority rp))) ;; Priority of request relative to other transactions. Currently, only used for scans.
     (is (= ReadModeAP/ONE (.readModeAP rp))) ;; Involve single node in the read operation.
     (is (= Replica/SEQUENCE (.replica rp))) ;; Try node containing master partition first.
     ;; If connection fails, all commands try nodes containing replicated partitions.
@@ -581,7 +580,6 @@
 
         rp ^Policy (.getReadPolicyDefault (client/get-client c))
         bp ^BatchPolicy (.getBatchPolicyDefault (client/get-client c))]
-    (is (= Priority/DEFAULT (.priority rp)))
     (is (= ReadModeAP/ALL (.readModeAP rp)))
     (is (= Replica/RANDOM (.replica rp)))
     (is (= 1000 (.socketTimeout rp)))
@@ -598,7 +596,6 @@
 
 (deftest default-write-policy
   (let [rp ^WritePolicy (.getWritePolicyDefault (client/get-client *c*))]
-    (is (= Priority/DEFAULT (.priority rp))) ;; Priority of request relative to other transactions. Currently, only used for scans.
     (is (= ReadModeAP/ONE (.readModeAP rp))) ;; Involve master only in the read operation.
     (is (= Replica/SEQUENCE (.replica rp))) ;; Try node containing master partition first.
     ;; If connection fails, all commands try nodes containing replicated partitions.
@@ -625,7 +622,6 @@
                                                               "respondAllOps"      true})})
 
         wp ^WritePolicy (.getWritePolicyDefault (client/get-client c))]
-    (is (= Priority/DEFAULT (.priority wp)))
     (is (= ReadModeAP/ONE (.readModeAP wp)))
     (is (true? (.durableDelete wp)))
     (is (= 1000 (.expiration wp)))


### PR DESCRIPTION
#### Updated:
* Bumped `com.aerospike/aerospike-client` to `4.4.18` ([release notes](https://download.aerospike.com/download/client/java/notes.html#4.4.18)).
* Bumped `funcool/promesa` to `6.0.2`.

#### Changed:
* Using a different method from `com.aerospike.client.Host` to parse a hosts strings
  that contains TLS names for seed nodes in order to allow connecting to a TLS-enabled
  cluster.