### PR TITLE
Fix mock for the `replace-only` function

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache
@@ -69,6 +70,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 5
     services:
       aerospike-test:
-        image: aerospike
+        image: aerospike:4.9.0.11
         ports:
           - 3000:3000
           - 3001:3001

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -10,18 +10,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Validate SNAPSHOT version
         env:
           SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
@@ -35,7 +41,8 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
+
+      - name: Run linters
         run: lein lint
 
   test:
@@ -54,17 +61,23 @@ jobs:
       AEROSPIKE_HOST: localhost
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Unit and integration tests
         run: lein test :all

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -48,7 +48,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     services:
       aerospike-test:

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 5
     services:
       aerospike-test:
-        image: aerospike
+        image: aerospike:4.9.0.11
         ports:
           - 3000:3000
           - 3001:3001

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     services:
       aerospike-test:
@@ -94,7 +94,7 @@ jobs:
 
   deploy:
     needs: test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -11,18 +11,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Validate SNAPSHOT version
         env:
           SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
@@ -36,12 +42,9 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
-        uses: DeLaGuardo/clojure-lint-action@v1
-        with:
-          clj-kondo-args: --lint src test --cache false
-          check-name: clj-kondo liniting report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run linters
+        run: lein lint
 
   test:
     needs: build
@@ -59,20 +62,27 @@ jobs:
       AEROSPIKE_HOST: localhost
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Unit and Integration tests
         run: lein eftest :all
+
       - name: Publish unit and integration test results
         uses: EnricoMi/publish-unit-test-result-action@v1.6
         if: always()
@@ -86,18 +96,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Deploy SNAPSHOT version
         env:
           SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache
@@ -70,6 +71,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache
@@ -104,6 +106,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 5
     services:
       aerospike-test:
-        image: aerospike
+        image: aerospike:4.9.0.11
         ports:
           - 3000:3000
           - 3001:3001

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     services:
       aerospike-test:
@@ -94,7 +94,7 @@ jobs:
 
   deploy:
     needs: test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 1.8
+          java-version: 8
 
       - name: Restore local Maven repository from cache
         uses: actions/cache@v3

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache
@@ -70,6 +71,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache
@@ -104,6 +106,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 1.8
 
       - name: Restore local Maven repository from cache

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -11,18 +11,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Validate SNAPSHOT version
         env:
           SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
@@ -36,12 +42,9 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
-        uses: DeLaGuardo/clojure-lint-action@v1
-        with:
-          clj-kondo-args: --lint src test --cache false
-          check-name: clj-kondo liniting report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run linters
+        run: lein lint
 
   test:
     needs: build
@@ -59,20 +62,27 @@ jobs:
       AEROSPIKE_HOST: localhost
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Unit and Integration tests
         run: lein eftest :all
+
       - name: Publish unit and integration test results
         uses: EnricoMi/publish-unit-test-result-action@v1.6
         if: always()
@@ -86,18 +96,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
+
       - name: Restore local Maven repository from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Deploy release version
         env:
           RELEASE_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ aerospike-clj.iml
 target
 .nrepl-port
 .lsp
+/.clj-kondo/.cache
+.java-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## This library follows [Semantic Versioning](https://semver.org).
 ## This CHANGELOG follows [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
+### VERSION 2.0.2
+#### Changed
+* The behavior of the mocked `replace-only`. 
+  It should throw an AerospikeException when the item doesn't exist.
+
 ### VERSION 2.0.1
 #### Updated
 * Links in README and CI config.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.appsflyer/aerospike-clj "2.0.1"
+(defproject com.appsflyer/aerospike-clj "2.0.2-SNAPSHOT"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                                      [cheshire "5.10.0"]
                                      [danlentz/clj-uuid "0.1.9"]
                                      [com.fasterxml.jackson.core/jackson-databind "2.11.2"]
-                                     [clj-kondo "RELEASE"]]
+                                     [clj-kondo "2021.01.20"]]
                     :aliases        {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                                      "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
                     :global-vars    {*warn-on-reflection* true}

--- a/src/main/clojure/aerospike_clj/mock_client.clj
+++ b/src/main/clojure/aerospike_clj/mock_client.clj
@@ -155,9 +155,9 @@
                       (let [transcoder (get-transcoder conf)
                             new-record (create-record (transcoder data) expiration)]
                         (set-record current-state new-record set-name k))
-                      (AerospikeException.
-                        ResultCode/KEY_NOT_FOUND_ERROR
-                        (str "Call to `replace-only` on non-existing key '" k "'"))))]
+                      (throw (AerospikeException.
+                               ResultCode/KEY_NOT_FOUND_ERROR
+                               (str "Call to `replace-only` on non-existing key '" k "'")))))]
       (do-swap state swap-fn)))
 
   (update [this k set-name new-record generation new-expiration]

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -347,9 +347,8 @@
       (try
         @(pt/replace-only client the-key the-set data ttl)
         (catch ExecutionException _))
-      (let [expected nil
-            actual   (pt/get-single client the-key the-set)]
-        (is (= @actual expected)))))
+      (let [actual (pt/get-single client the-key the-set)]
+        (is (nil? @actual)))))
 
   (testing "it should update an item if it exists"
     (let [the-key       "foo"


### PR DESCRIPTION
In this PR:
- It should throw an AerospikeException when the item doesn't exist.
- Currently, it replaces the underlying data with an AerospikeException type object.
- Cover the behavior with unit tests
- Use a pinned version of `clj-kondo`.
- Related to the CI:
  - Use a pinned version of Aerospike.
  - Use the latest LTS version of ubuntu.
  - Stop using `clojure-lint-action`, it's getting throttled by docker hub. (See [this](https://github.com/evg-tso/aerospike-clj/runs/7486456079?check_suite_focus=true) run)
  - Bump versions of `actions/checkout`, `actions/setup-java` and `actions/cache`.