### PR TITLE
2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Unreleased
 
-### VERSION 2.0.4
+### VERSION 2.0.5
 #### Changed
 * TTLs for the mock client are now correctly mocked:
   * TTL is stored (and returned in get operations) as seconds from Aerospike epoch time

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.appsflyer/aerospike-clj "2.0.4-SNAPSHOT"
+(defproject com.appsflyer/aerospike-clj "2.0.5-SNAPSHOT"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
2.0.4 was accidentally pushed to Clojars (duplicate of 2.0.3).