### PR TITLE
Optimize `aerospike-record/record->map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### Unreleased
 
+### VERSION 2.0.6
+#### Changed
+* Performance and memory optimization, mainly in the core `aerospike-clj.aerospike-record/record->map` function.
+
 ### VERSION 2.0.5
 #### Changed
 * TTLs for the mock client are now correctly mocked:

--- a/src/main/clojure/aerospike_clj/utils.clj
+++ b/src/main/clojure/aerospike_clj/utils.clj
@@ -1,6 +1,6 @@
 (ns aerospike-clj.utils
   (:require [clojure.set :as set])
-  (:import [java.util Collection]))
+  (:import (java.util Collection)))
 
 (def ^:private boolean-replacements
   "For bins, Aerospike converts `true` to `1`, `false` to `0` and `nil` values are
@@ -11,12 +11,7 @@
    false :false
    nil   :nil})
 
-;; transducers
-(def ^:private x-sanitize
-  (replace boolean-replacements))
-
-(def ^:private x-desanitize
-  (replace (set/map-invert boolean-replacements)))
+(def ^:private reverse-boolean-replacements (set/map-invert boolean-replacements))
 
 ;; predicates
 (defn single-bin?
@@ -35,14 +30,12 @@
   however, `true`, `false` or `nil` exist as the only value in a bin, they need to
   be sanitized."
   [bin-value]
-  (->> (into [] x-sanitize (vector bin-value))
-       first))
+  (get boolean-replacements bin-value bin-value))
 
 (defn desanitize-bin-value
   "Converts sanitized (keywordized) bin values back to their original value."
   [bin-value]
-  (->> (into [] x-desanitize (vector bin-value))
-       first))
+  (get reverse-boolean-replacements bin-value bin-value))
 
 (defn v->array
   "An optimized way to convert vectors into Java arrays of type `clazz`."


### PR DESCRIPTION
In this PR:

1. Avoid costly `(into {} ..)`, we can use the original `(.bins record)`.
2. No need for the `keys` function, since we can rely on the previously extracted `(.bins record)`.
3. `sanitize-bin-value` and `desanitize-bin-value` don't need to transform a single item to a vector, apply a transducer on it while copying it into a second array and extract the first item from the result, this can be unrolled into a single `(get ...)` function.
4. Use `Map`'s methods to determine if it is a single bin, and avoid costly vector comparison.

See the attached CPU sampling flame graph to see the tackled hot spots.  
![image](https://user-images.githubusercontent.com/1637415/204539697-81e28eca-af30-4374-b41f-7307fa415a1c.png)
