### PR TITLE
Support the usage of `com.aerospike/aerospike-client` with versions 4.9 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Introduce a `aerospike-clj.batch-policy` namespace.
     This namespace contains functions to create batch policies for the Aerospike Java client library. 
 
+#### Removed
+
+* Remove `:result-code` from the `get-batch`'s response.
+
 ### [3.1.0] - 2023-08-22
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0] - 2024-01-14
+
+#### Changed
+
+* Introduce a `aerospike-clj.batch-client` namespace.
+  This namespace extends the `aerospike-clj.client` namespace with batch operations using the `AerospikeBatchOps`
+  protocol.
+* This will allow clients to use the `aerospike-clj.client` namespace with older versions of the Aerospike Java client
+  library, and use the `aerospike-clj.batch-client` namespace with newer versions of the Aerospike Java client library.
+
 ### [3.1.0] - 2023-08-22
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-* Introduce a `aerospike-clj.batch-client` namespace.
-  This namespace extends the `aerospike-clj.client` namespace with batch operations using the `AerospikeBatchOps`
-  protocol.
-* This will allow clients to use the `aerospike-clj.client` namespace with older versions of the Aerospike Java client
-  library, and use the `aerospike-clj.batch-client` namespace with newer versions of the Aerospike Java client library.
+* Enable the usage of `com.aerospike/aerospike-client` with versions 4.9 and up.
+  * Introduce a `aerospike-clj.batch-client` namespace.
+    This namespace extends the `aerospike-clj.client` namespace with batch operations using the `AerospikeBatchOps`
+    protocol, which is relevant for Java client library versions 6.0.0 and up.
+  * Introduce a `aerospike-clj.batch-policy` namespace.
+    This namespace contains functions to create batch policies for the Aerospike Java client library. 
 
 ### [3.1.0] - 2023-08-22
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ user=> @(aero/get-single c "index" "set-name")
 Aerospike returns a TTL on the queried records that is epoch style, but with a different "beginning of time" which is "2010-01-01T00:00:00Z".
 Call `expiry-unix` with the returned TTL to get a TTL relative to the UNIX epoch.
 
+### Using the `AerospikeBatchOps` protocol
+
+Since library version `4.0.0`, the implementation of the `AerospikeBatchOps` protocol is available as an extension to
+the `aerospike-clj.client` namespace.  
+The extension is available via the `aerospike-clj.batch-client` namespace.  
+To use it, require the `aerospike-clj.batch-client` namespace.  
+The implementation of the `AerospikeBatchOps` protocol is implemented in a separate namespace to allow older versions of
+the `com.aerospike/aerospike-client` dependency to be used.
+Please note that the `aerospike-clj.batch-client` namespace requires the `com.aerospike/aerospike-client` dependency to
+be version `6.0.0` or higher.
+
 ## Testing
 ### Unit tests
 Executed via running `lein test`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ An opinionated Clojure library wrapping Aerospike Java Client.
 
 # Requirements
 - Java 8
-- Clojure 1.8
 - Aerospike server version >= `4.9.0`
 - Clojure version >= `1.11.0`
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ the `com.aerospike/aerospike-client` dependency to be used.
 Please note that the `aerospike-clj.batch-client` namespace requires the `com.aerospike/aerospike-client` dependency to
 be version `6.0.0` or higher.
 
+### Setting up a client policy for `com.aerospike/aerospike-client` with version 6.0.0 and above
+
+The `com.aerospike/aerospike-client` dependency version `6.0.0` is a breaking change.  
+To set batch operation policies, please use the `aerospike-clj.batch-policy` namespace.
+
 ## Testing
 ### Unit tests
 Executed via running `lein test`.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.appsflyer/aerospike-clj "3.1.0"
+(defproject com.appsflyer/aerospike-clj "4.0.0-SNAPSHOT"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"
@@ -23,7 +23,7 @@
                                      [cheshire "5.11.0"]
                                      [tortue/spy "2.14.0"]
                                      [com.fasterxml.jackson.core/jackson-databind "2.11.2"]
-                                     [clj-kondo "2023.09.07"]
+                                     [clj-kondo "2023.12.15"]
                                      [com.clojure-goes-fast/clj-java-decompiler "0.3.4"]]
                     :eftest         {:multithread?   false
                                      :report         eftest.report.junit/report

--- a/src/main/clojure/aerospike_clj/batch_client.clj
+++ b/src/main/clojure/aerospike_clj/batch_client.clj
@@ -1,0 +1,42 @@
+(ns aerospike-clj.batch-client
+  (:require [aerospike-clj.aerospike-record :as record]
+            [aerospike-clj.client :as client]
+            [aerospike-clj.collections :as collections]
+            [aerospike-clj.protocols :as pt]
+            [promesa.core :as p])
+  (:import (aerospike_clj.client SimpleAerospikeClient)
+           (aerospike_clj.listeners AsyncBatchOperateListListener)
+           (com.aerospike.client AerospikeClient BatchRecord)
+           (com.aerospike.client.async EventLoop EventLoops)
+           (com.aerospike.client.listener BatchOperateListListener)
+           (com.aerospike.client.policy BatchPolicy)
+           (java.util List)))
+
+(defn- batch-record->map [^BatchRecord batch-record]
+  (let [k (.key batch-record)]
+    (-> (record/record->map (.record batch-record))
+        (assoc :index (.toString (.userKey k)))
+        (assoc :set (.setName k))
+        (assoc :result-code (.resultCode batch-record)))))
+
+(extend-type SimpleAerospikeClient
+  pt/AerospikeBatchOps
+  (batch-operate [this batch-records]
+    (pt/batch-operate this batch-records {}))
+
+  (batch-operate [this batch-records conf]
+    (let [op-future  (p/deferred)
+          policy     (:policy conf)
+          batch-list (if (list? batch-records)
+                       batch-records
+                       (into [] batch-records))
+          start-time (System/nanoTime)
+          transcoder (:transcoder conf identity)]
+      (.operate ^AerospikeClient (.-client this)
+                ^EventLoop (.next ^EventLoops (.-el this))
+                ^BatchOperateListListener (AsyncBatchOperateListListener. op-future)
+                ^BatchPolicy policy
+                ^List batch-list)
+      (-> op-future
+          (p/then' (comp transcoder #(collections/->list batch-record->map %)) (.-completion-executor this))
+          (client/register-events (.-client-events this) :batch-operate nil start-time conf)))))

--- a/src/main/clojure/aerospike_clj/batch_client.clj
+++ b/src/main/clojure/aerospike_clj/batch_client.clj
@@ -1,4 +1,7 @@
 (ns aerospike-clj.batch-client
+  "This namespace contains implementation of the [[AerospikeBatchOps]] protocol.
+   Clients should `require` this namespace to extend the protocol to the [[SimpleAerospikeClient]].
+   This protocol is only usable with `com.aerospike/aerospike-client` version 6.0.0 or higher."
   (:require [aerospike-clj.aerospike-record :as record]
             [aerospike-clj.client :as client]
             [aerospike-clj.collections :as collections]

--- a/src/main/clojure/aerospike_clj/batch_client.clj
+++ b/src/main/clojure/aerospike_clj/batch_client.clj
@@ -21,22 +21,22 @@
 
 (extend-type SimpleAerospikeClient
   pt/AerospikeBatchOps
-  (batch-operate [this batch-records]
-    (pt/batch-operate this batch-records {}))
-
-  (batch-operate [this batch-records conf]
-    (let [op-future  (p/deferred)
-          policy     (:policy conf)
-          batch-list (if (list? batch-records)
-                       batch-records
-                       (into [] batch-records))
-          start-time (System/nanoTime)
-          transcoder (:transcoder conf identity)]
-      (.operate ^AerospikeClient (.-client this)
-                ^EventLoop (.next ^EventLoops (.-el this))
-                ^BatchOperateListListener (AsyncBatchOperateListListener. op-future)
-                ^BatchPolicy policy
-                ^List batch-list)
-      (-> op-future
-          (p/then' (comp transcoder #(collections/->list batch-record->map %)) (.-completion-executor this))
-          (client/register-events (.-client-events this) :batch-operate nil start-time conf)))))
+  (batch-operate
+    ([this batch-records]
+     (pt/batch-operate this batch-records {}))
+    ([this batch-records conf]
+     (let [op-future  (p/deferred)
+           policy     (:policy conf)
+           batch-list (if (list? batch-records)
+                        batch-records
+                        (into [] batch-records))
+           start-time (System/nanoTime)
+           transcoder (:transcoder conf identity)]
+       (.operate ^AerospikeClient (.-client this)
+                 ^EventLoop (.next ^EventLoops (.-el this))
+                 ^BatchOperateListListener (AsyncBatchOperateListListener. op-future)
+                 ^BatchPolicy policy
+                 ^List batch-list)
+       (-> op-future
+           (p/then' (comp transcoder #(collections/->list batch-record->map %)) (.-completion-executor this))
+           (client/register-events (.-client-events this) :batch-operate nil start-time conf))))))

--- a/src/main/clojure/aerospike_clj/batch_policy.clj
+++ b/src/main/clojure/aerospike_clj/batch_policy.clj
@@ -1,6 +1,7 @@
 (ns aerospike-clj.batch-policy
   (:require [aerospike-clj.policy :as policy])
-  (:import (com.aerospike.client.policy BatchPolicy BatchWritePolicy ClientPolicy)))
+  (:import #_{:clj-kondo/ignore [:unused-import]}
+    (com.aerospike.client.policy BatchPolicy BatchWritePolicy ClientPolicy RecordExistsAction)))
 
 (defn map->batch-policy
   "Create a `BatchPolicy` from a map.

--- a/src/main/clojure/aerospike_clj/batch_policy.clj
+++ b/src/main/clojure/aerospike_clj/batch_policy.clj
@@ -1,4 +1,6 @@
 (ns aerospike-clj.batch-policy
+  "This namespace contains functions to create batch policies.
+   These policies are only usable with `com.aerospike/aerospike-client` version 6.0.0 or higher."
   (:require [aerospike-clj.policy :as policy])
   (:import #_{:clj-kondo/ignore [:unused-import]}
     (com.aerospike.client.policy BatchPolicy

--- a/src/main/clojure/aerospike_clj/batch_policy.clj
+++ b/src/main/clojure/aerospike_clj/batch_policy.clj
@@ -1,0 +1,36 @@
+(ns aerospike-clj.batch-policy
+  (:require [aerospike-clj.policy :as policy])
+  (:import (com.aerospike.client.policy BatchPolicy BatchWritePolicy ClientPolicy)))
+
+(defn map->batch-policy
+  "Create a `BatchPolicy` from a map.
+  This function is slow due to possible reflection."
+  ^BatchPolicy [conf]
+  (let [bp   (BatchPolicy. (policy/map->policy conf))
+        conf (merge {"timeoutDelay" 3000} conf)]
+    (policy/set-java bp conf "allowInline")
+    (policy/set-java bp conf "respondAllKeys")
+    (policy/set-java bp conf "maxConcurrentThreads")
+    (policy/set-java bp conf "sendSetName")
+    bp))
+
+(defn map->batch-write-policy
+  "Create a `BatchWritePolicy` from a map. Enumeration names should start with capitalized letter.
+  This function is slow due to possible reflection."
+  ^BatchWritePolicy [conf]
+  (let [p (BatchWritePolicy.)]
+    (policy/set-java-enum p conf "RecordExistsAction")
+    (policy/set-java-enum p conf "CommitLevel")
+    (policy/set-java-enum p conf "GenerationPolicy")
+    (policy/set-java p conf "filterExp")
+    (policy/set-java p conf "generation")
+    (policy/set-java p conf "expiration")
+    (policy/set-java p conf "durableDelete")
+    (policy/set-java p conf "sendKey")
+    p))
+
+(defn add-batch-write-policy
+  "Set the [[batchWritePolicyDefault]] or the [[batchParentPolicyWriteDefault]] in a [[ClientPolicy]]."
+  [^ClientPolicy client-policy conf]
+  (set! (.batchParentPolicyWriteDefault client-policy) (get conf "batchParentPolicyWriteDefault" (map->batch-policy conf)))
+  (set! (.batchWritePolicyDefault client-policy) (get conf "batchWritePolicyDefault" (map->batch-write-policy conf))))

--- a/src/main/clojure/aerospike_clj/batch_policy.clj
+++ b/src/main/clojure/aerospike_clj/batch_policy.clj
@@ -1,7 +1,12 @@
 (ns aerospike-clj.batch-policy
   (:require [aerospike-clj.policy :as policy])
   (:import #_{:clj-kondo/ignore [:unused-import]}
-    (com.aerospike.client.policy BatchPolicy BatchWritePolicy ClientPolicy RecordExistsAction)))
+    (com.aerospike.client.policy BatchPolicy
+                                 BatchWritePolicy
+                                 ClientPolicy
+                                 CommitLevel
+                                 GenerationPolicy
+                                 RecordExistsAction)))
 
 (defn map->batch-policy
   "Create a `BatchPolicy` from a map.
@@ -35,3 +40,10 @@
   [^ClientPolicy client-policy conf]
   (set! (.batchParentPolicyWriteDefault client-policy) (get conf "batchParentPolicyWriteDefault" (map->batch-policy conf)))
   (set! (.batchWritePolicyDefault client-policy) (get conf "batchWritePolicyDefault" (map->batch-write-policy conf))))
+
+(defn create-client-policy
+  "This is a wrapper around [[policy/create-client-policy]] that adds the batch policies to the client policy."
+  ^ClientPolicy [event-loops conf]
+  (let [client-policy (policy/create-client-policy event-loops conf)]
+    (add-batch-write-policy client-policy conf)
+    client-policy))

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -79,12 +79,11 @@
   (create-key ^Key [this as-namespace set-name]
     (as-key/create-key this as-namespace set-name)))
 
-(defn batch-read->map [^BatchRead batch-record]
-  (let [k (.key batch-record)]
-    (-> (record/record->map (.record batch-record))
+(defn batch-read->map [^BatchRead batch-read]
+  (let [k (.key batch-read)]
+    (-> (record/record->map (.record batch-read))
         (assoc :index (.toString (.userKey k)))
-        (assoc :set (.setName k))
-        (assoc :result-code (.resultCode batch-record)))))
+        (assoc :set (.setName k)))))
 
 (defn- map->batch-read ^BatchRead [batch-read-map dbns]
   (let [k ^Key (pt/create-key (:index batch-read-map) dbns (:set batch-read-map))]

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -13,19 +13,18 @@
             [clojure.tools.logging :as log]
             [promesa.core :as p]
             [promesa.exec :as p-exec])
-  (:import (aerospike_clj.listeners AsyncBatchListListener AsyncBatchOperateListListener AsyncDeleteListener
+  (:import (aerospike_clj.listeners AsyncBatchListListener AsyncDeleteListener
                                     AsyncExistsArrayListener AsyncExistsListener AsyncInfoListener
                                     AsyncRecordListener AsyncRecordSequenceListener AsyncWriteListener)
-           (com.aerospike.client BatchRecord Host Key)
+           (com.aerospike.client Host Key)
            (com.aerospike.client AerospikeClient BatchRead Bin Key Operation)
            (com.aerospike.client.async EventLoop EventLoops NioEventLoops)
            (com.aerospike.client.cluster Node)
-           (com.aerospike.client.listener BatchOperateListListener)
            (com.aerospike.client.policy BatchPolicy ClientPolicy InfoPolicy
                                         Policy RecordExistsAction ScanPolicy
                                         WritePolicy)
            (java.time Instant)
-           (java.util Arrays List)
+           (java.util Arrays)
            (java.util.concurrent Executor)))
 
 (def
@@ -66,7 +65,7 @@
         (p/catch (fn [op-exception]
                    (pt/on-failure client-events op-name op-exception index op-start-time))))))
 
-(defn- register-events [op-future default-client-events op-name index op-start-time conf]
+(defn register-events [op-future default-client-events op-name index op-start-time conf]
   (let [client-events (:client-events conf default-client-events)]
     (if (empty? client-events)
       op-future
@@ -80,7 +79,7 @@
   (create-key ^Key [this as-namespace set-name]
     (as-key/create-key this as-namespace set-name)))
 
-(defn- batch-record->map [^BatchRecord batch-record]
+(defn batch-read->map [^BatchRead batch-record]
   (let [k (.key batch-record)]
     (-> (record/record->map (.record batch-record))
         (assoc :index (.toString (.userKey k)))
@@ -183,7 +182,7 @@
             ^BatchPolicy (:policy conf)
             batch-reads-arr)
       (-> op-future
-          (p/then' #(collections/->list batch-record->map %) completion-executor)
+          (p/then' #(collections/->list batch-read->map %) completion-executor)
           (p/then' (:transcoder conf identity))
           (register-events client-events :read-batch nil start-time conf))))
 
@@ -366,28 +365,6 @@
         (-> op-future
             (p/then' record/record->map completion-executor)
             (register-events client-events :operate index start-time conf)))))
-
-  pt/AerospikeBatchOps
-  (batch-operate [this batch-records]
-    (pt/batch-operate this batch-records {}))
-
-  (batch-operate [_this batch-records conf]
-    (let [op-future  (p/deferred)
-          policy     (:policy conf)
-          batch-list (if (list? batch-records)
-                       batch-records
-                       (into [] batch-records))
-          start-time (System/nanoTime)
-          transcoder (:transcoder conf identity)]
-      (.operate ^AerospikeClient client
-                ^EventLoop (.next ^EventLoops el)
-                ^BatchOperateListListener (AsyncBatchOperateListListener. op-future)
-                ^BatchPolicy policy
-                ^List batch-list)
-      (-> op-future
-          (p/then' (comp transcoder #(collections/->list batch-record->map %)) completion-executor)
-          (register-events client-events :batch-operate nil start-time conf))))
-
 
   pt/AerospikeSetOps
   (scan-set [_this aero-namespace set-name conf]

--- a/src/main/clojure/aerospike_clj/listeners.clj
+++ b/src/main/clojure/aerospike_clj/listeners.clj
@@ -1,10 +1,10 @@
 (ns aerospike-clj.listeners
-  (:require [promesa.core :as p]
-            [aerospike-clj.aerospike-record :as record])
-  (:import (java.util List Map)
-           (com.aerospike.client Key Record AerospikeException AerospikeException$QueryTerminated)
-           (com.aerospike.client.listener RecordListener WriteListener DeleteListener
-                                          ExistsListener BatchListListener RecordSequenceListener InfoListener ExistsArrayListener BatchOperateListListener)))
+  (:require [aerospike-clj.aerospike-record :as record]
+            [promesa.core :as p])
+  (:import (com.aerospike.client AerospikeException AerospikeException$QueryTerminated Key Record)
+           (com.aerospike.client.listener BatchListListener DeleteListener
+                                          ExistsArrayListener ExistsListener InfoListener RecordListener RecordSequenceListener WriteListener)
+           (java.util List Map)))
 
 (deftype AsyncExistsListener [op-future]
   ExistsListener
@@ -66,10 +66,3 @@
     (p/reject! op-future ex))
   (^void onSuccess [_this ^"[Lcom.aerospike.client.Key;" _keys ^"[Z" exists]
     (p/resolve! op-future exists)))
-
-(deftype AsyncBatchOperateListListener [op-future]
-  BatchOperateListListener
-  (^void onSuccess [_this ^List records ^boolean _status]
-    (p/resolve! op-future records))
-  (^void onFailure [_this ^AerospikeException ex]
-    (p/reject! op-future ex)))

--- a/src/main/clojure/aerospike_clj/policy.clj
+++ b/src/main/clojure/aerospike_clj/policy.clj
@@ -4,7 +4,7 @@
     #_{:clj-kondo/ignore [:unused-import]}
            [com.aerospike.client.policy Policy ClientPolicy WritePolicy RecordExistsAction
                                         GenerationPolicy BatchPolicy CommitLevel
-                                        AuthMode ReadModeAP ReadModeSC Replica BatchWritePolicy]))
+                                        AuthMode ReadModeAP ReadModeSC Replica]))
 
 (defmacro set-java [obj conf obj-name]
   `(when (some? (get ~conf ~obj-name))
@@ -36,21 +36,6 @@
     (set-java p conf "socketTimeout")
     (set-java p conf "timeoutDelay")
     (set-java p conf "totalTimeout")
-    p))
-
-(defn map->batch-write-policy
-  "Create a `BatchWritePolicy` from a map. Enumeration names should start with capitalized letter.
-  This function is slow due to possible reflection."
-  ^BatchWritePolicy [conf]
-  (let [p (BatchWritePolicy.)]
-    (set-java-enum p conf "RecordExistsAction")
-    (set-java-enum p conf "CommitLevel")
-    (set-java-enum p conf "GenerationPolicy")
-    (set-java p conf "filterExp")
-    (set-java p conf "generation")
-    (set-java p conf "expiration")
-    (set-java p conf "durableDelete")
-    (set-java p conf "sendKey")
     p))
 
 (defn map->batch-policy
@@ -88,18 +73,6 @@
    (write-policy client expiration (RecordExistsAction/REPLACE)))
   (^WritePolicy [client expiration record-exists-action]
    (let [wp (WritePolicy. (.getWritePolicyDefault ^AerospikeClient client))]
-     (set! (.expiration wp) expiration)
-     (set! (.recordExistsAction wp) record-exists-action)
-     wp)))
-
-(defn batch-write-policy
-  "Create a write policy to be passed to put methods via `{:policy wp}`.
-  Also used in `update` and `create`.
-  The default policy in case the record exists is `RecordExistsAction/UPDATE`."
-  (^BatchWritePolicy [client expiration]
-   (batch-write-policy client expiration (RecordExistsAction/UPDATE)))
-  (^BatchWritePolicy [client expiration record-exists-action]
-   (let [wp (BatchWritePolicy. (.getBatchWritePolicyDefault ^AerospikeClient client))]
      (set! (.expiration wp) expiration)
      (set! (.recordExistsAction wp) record-exists-action)
      wp)))
@@ -187,8 +160,6 @@
     (set! (.readPolicyDefault cp) (get conf "readPolicyDefault" (map->policy conf)))
     (set! (.writePolicyDefault cp) (get conf "writePolicyDefault" (map->write-policy conf)))
     (set! (.batchPolicyDefault cp) (get conf "batchPolicyDefault" (map->batch-policy conf)))
-    (set! (.batchParentPolicyWriteDefault cp) (get conf "batchParentPolicyWriteDefault" (map->batch-policy conf)))
-    (set! (.batchWritePolicyDefault cp) (get conf "batchWritePolicyDefault" (map->batch-write-policy conf)))
 
     (set-java-enum cp conf "AuthMode")
     (set-java cp conf "clusterName")

--- a/test/aerospike_clj/integration/integration_test.clj
+++ b/test/aerospike_clj/integration/integration_test.clj
@@ -5,12 +5,12 @@
             [clojure.test :refer [deftest testing is use-fixtures]]
             [cheshire.core :as json]
             [aerospike-clj.integration.aerospike-setup :as as-setup]
+            [aerospike-clj.batch-policy :as batch-policy]
             [aerospike-clj.client :as client]
             [aerospike-clj.protocols :as pt]
             [aerospike-clj.policy :as policy]
             [aerospike-clj.key :as as-key]
             [aerospike-clj.utils :as utils]
-            [clojure.tools.logging :as log]
             [spy.core :as spy])
   (:import (com.aerospike.client Value AerospikeClient BatchWrite Operation Bin)
            (com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
@@ -652,13 +652,13 @@
   (let [expression                (Exp/build (Exp/ge (Exp/intBin "a") (Exp/intBin "b")))
         c                         (client/init-simple-aerospike-client
                                     *as-hosts* as-namespace
-                                    {"batchWritePolicyDefault"       (policy/map->batch-write-policy {"CommitLevel"        "COMMIT_MASTER"
-                                                                                                      "durableDelete"      true
-                                                                                                      "expiration"         1000
-                                                                                                      "generation"         7
-                                                                                                      "GenerationPolicy"   "EXPECT_GEN_GT"
-                                                                                                      "RecordExistsAction" "REPLACE_ONLY"
-                                                                                                      "filterExp"          expression})
+                                    {"batchWritePolicyDefault"       (batch-policy/map->batch-write-policy {"CommitLevel"        "COMMIT_MASTER"
+                                                                                                            "durableDelete"      true
+                                                                                                            "expiration"         1000
+                                                                                                            "generation"         7
+                                                                                                            "GenerationPolicy"   "EXPECT_GEN_GT"
+                                                                                                            "RecordExistsAction" "REPLACE_ONLY"
+                                                                                                            "filterExp"          expression})
                                      "batchParentPolicyWriteDefault" (policy/map->batch-policy {"allowInline"          false
                                                                                                 "maxConcurrentThreads" 2
                                                                                                 "sendSetName"          true})})

--- a/test/aerospike_clj/integration/integration_test.clj
+++ b/test/aerospike_clj/integration/integration_test.clj
@@ -1,7 +1,8 @@
 (ns ^{:author      "Ido Barkan"
       :integration true}
   aerospike-clj.integration.integration-test
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [aerospike-clj.batch-client]
+            [clojure.test :refer [deftest testing is use-fixtures]]
             [cheshire.core :as json]
             [aerospike-clj.integration.aerospike-setup :as as-setup]
             [aerospike-clj.client :as client]
@@ -9,6 +10,7 @@
             [aerospike-clj.policy :as policy]
             [aerospike-clj.key :as as-key]
             [aerospike-clj.utils :as utils]
+            [clojure.tools.logging :as log]
             [spy.core :as spy])
   (:import (com.aerospike.client Value AerospikeClient BatchWrite Operation Bin)
            (com.aerospike.client.cdt ListOperation ListPolicy ListOrder ListWriteFlags ListReturnType
@@ -27,7 +29,6 @@
 (def ^:dynamic *c* nil)
 (def ^:dynamic *as-hosts* nil)
 (def TTL 5)
-
 
 (defn with-db-connection [test-fn]
   (let [as-hosts [(as-setup/get-host-and-port)]]


### PR DESCRIPTION
In this PR:  

## Changed

* Enable the usage of `com.aerospike/aerospike-client` with versions 4.9 and up.
  * Introduce a `aerospike-clj.batch-client` namespace.
    This namespace extends the `aerospike-clj.client` namespace with batch operations using the `AerospikeBatchOps`
    protocol, which is relevant for Java client library versions 6.0.0 and up.
  * Introduce a `aerospike-clj.batch-policy` namespace.
    This namespace contains functions to create batch policies for the Aerospike Java client library.

## Removed

* Remove `:result-code` from the `get-batch`'s response.