### PR TITLE
bugfix - the function `healthy?` should not overwrite default policy's totalTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* **BREAKING**: `AerospikeAdminOps/healthy?` 2-arity now applies the timeout to
-  a dedicated read policy instead of mutating the client's shared
-  `readPolicyDefault`. 
-  
-  The is a breaking change because the previous implementation mutated the shared
-  `readPolicyDefault` instance on the underlying `AerospikeClient` in-place,
-  permanently overwriting the configured `totalTimeout` for all subsequent
-  operations that relied on the default policy. 
+* **BREAKING**: `AerospikeAdminOps/healthy?` now relies on the client's
+  initialized health policy (default total timeout: 1000ms) instead of accepting
+  a timeout override per call. This removes mutation of the shared
+  `readPolicyDefault` on the underlying `AerospikeClient`, which previously
+  could permanently overwrite the configured `totalTimeout`.
 
 * Fixed a health check regression: the write TTL now uses `max 1` when deriving
   TTL from `:totalTimeout`, so very small timeouts no longer produce a `0`
   TTL (which could skip retention and make checks flaky).
 
 ### Changed   
+
+* `AerospikeAdminOps/healthy?` protocol now exposes only the zero-arity
+  `healthy? [this]` contract. Timeout customization is configured at client
+  initialization via `:health-policy` instead of through the protocol call.
 
 * `init-simple-aerospike-client` now accepts `:health-policy` in its `conf`
   map as string-keyed read-policy overrides. The configured value is applied on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{\"totalTimeout\" 1000}` fallback. This makes health check behavior
   configurable per client without mutating any shared default policy object.
 
-
 ### [3.1.0] - 2023-08-22
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-03-11
+
+### Changed
+
+* **BREAKING**: `AerospikeAdminOps/healthy?` 2-arity now accepts a
+  `com.aerospike.client.policy.Policy` instead of an `operation-timeout-ms`
+  integer. The 1-arity default behavior is unchanged (totalTimeout of 1000ms),
+  but callers using the 2-arity must now pass a pre-built `Policy` object.
+
+  Before:
+  ```clojure
+  (pt/healthy? client 500)
+  ```
+  After:
+  ```clojure
+  (pt/healthy? client (doto (Policy.) (set! -totalTimeout 500)))
+  ```
+
+  **Rationale**: The previous implementation mutated the shared
+  `readPolicyDefault` instance on the underlying `AerospikeClient` in-place,
+  permanently overwriting the configured `totalTimeout` for all subsequent
+  operations that relied on the default policy. Passing an explicit `Policy`
+  eliminates this shared-state mutation entirely.
+
 ### [3.1.0] - 2023-08-22
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.0] - 2026-03-11
 
-### Changed
+### Fixed
 
-* **BREAKING**: `AerospikeAdminOps/healthy?` 2-arity now accepts a
-  `com.aerospike.client.policy.Policy` instead of an `operation-timeout-ms`
-  integer. The 1-arity default behavior is unchanged (totalTimeout of 1000ms),
-  but callers using the 2-arity must now pass a pre-built `Policy` object.
-
-  Before:
-  ```clojure
-  (pt/healthy? client 500)
-  ```
-  After:
-  ```clojure
-  (pt/healthy? client (doto (Policy.) (set! -totalTimeout 500)))
-  ```
-
-  **Rationale**: The previous implementation mutated the shared
+* **BREAKING**: `AerospikeAdminOps/healthy?` 2-arity now applies the timeout to
+  a dedicated read policy instead of mutating the client's shared
+  `readPolicyDefault`. 
+  
+  The is a breaking change because the previous implementation mutated the shared
   `readPolicyDefault` instance on the underlying `AerospikeClient` in-place,
   permanently overwriting the configured `totalTimeout` for all subsequent
-  operations that relied on the default policy. Passing an explicit `Policy`
-  eliminates this shared-state mutation entirely.
+  operations that relied on the default policy. 
+
+* Fixed a health check regression: the write TTL now uses `max 1` when deriving
+  TTL from `:totalTimeout`, so very small timeouts no longer produce a `0`
+  TTL (which could skip retention and make checks flaky).
+
+### Changed   
+
+* `init-simple-aerospike-client` now accepts `:health-policy` in its `conf`
+  map as string-keyed read-policy overrides. The configured value is applied on
+  top of the resolved client policy's `readPolicyDefault`, with a default
+  `{\"totalTimeout\" 1000}` fallback. This makes health check behavior
+  configurable per client without mutating any shared default policy object.
+
 
 ### [3.1.0] - 2023-08-22
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -105,6 +105,19 @@ user=> (.commitLevel (.writePolicyDefault (.client ^SimpleAerospikeClient c)))
 #object[com.aerospike.client.policy.CommitLevel 0x2f1f3fef "COMMIT_MASTER"]
 ```
 
+Health checks are also configurable on initialization via `:health-policy`. The client
+creates a dedicated read policy for health checks from the base
+`readPolicyDefault` and applies any overrides from this map. If omitted, it defaults
+to `{"totalTimeout" 1000}`.
+```clojure
+user=> (def c (client/init-simple-aerospike-client
+               ["localhost"]
+               "test"
+               {"health-policy" {"totalTimeout" 2000
+                                "ReadModeSC"  "LINEARIZE"}}))
+#'user/c
+```
+
 Those `AerospikeClient` fields are `final` hence can only be set on client creation,
 but you can also have a few useful policies `def`ed somewhere and pass them later
 under the `:policy` key of the API calls.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.appsflyer/aerospike-clj "3.1.0"
+(defproject com.appsflyer/aerospike-clj "4.0.0"
   :description "An Aerospike Clojure client."
   :url "https://github.com/AppsFlyer/aerospike-clj"
   :license {:name "Eclipse Public License"

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -113,7 +113,8 @@
                                 hosts
                                 dbns
                                 client-events
-                                close-event-loops?]
+                                close-event-loops?
+                                health-policy]
   pt/AerospikeReadOps
   (get-single [this index set-name]
     (pt/get-single this index set-name {} [:all]))
@@ -238,9 +239,9 @@
 
   (put-multiple [this indices set-names payloads expirations conf]
     (p/all
-      (map (fn [[index set-name payload expiration]]
-             (pt/put this index set-name payload expiration conf))
-           (map vector indices set-names payloads expirations))))
+     (map (fn [[index set-name payload expiration]]
+            (pt/put this index set-name payload expiration conf))
+          (map vector indices set-names payloads expirations))))
 
   pt/AerospikeUpdateOps
   (set-single [this index set-name data expiration]
@@ -433,22 +434,21 @@
         metrics/cluster-metrics->dotted))
 
   (healthy? [this]
-    (let [p (Policy. (.readPolicyDefault ^AerospikeClient client))]
-      (set! (.totalTimeout p) 1000)
-      (pt/healthy? this p)))
+    (pt/healthy? this health-policy))
 
-  (healthy? [this read-policy]
-    (let [k        (str "__health__" (rand-int Integer/MAX_VALUE))
-          v        (rand-int Integer/MAX_VALUE)
-          ttl      (max 1 (int (/ (.totalTimeout ^Policy read-policy) 1000)))
-          set-name "__health-check"]
-      (try
-        @(pt/put this k set-name v ttl)
-        (= v
-           @(pt/get-single this k set-name {:transcoder :payload
-                                            :policy     read-policy}))
-        (catch Exception _ex
-          false))))
+  (healthy? [this operation-timeout-ms]
+    (let [health-policy (set! (.totalTimeout health-policy) operation-timeout-ms)
+       k           (str "__health__" (rand-int Integer/MAX_VALUE))
+       v           (rand-int Integer/MAX_VALUE)
+       ttl         (max 1 (int (/ operation-timeout-ms 1000)))
+       set-name    "__health-check"]
+   (try
+     @(pt/put this k set-name v ttl)
+     (= v
+        @(pt/get-single this k set-name {:transcoder :payload
+                                         :policy     health-policy}))
+     (catch Exception _ex
+       false))))
 
   (stop [_this]
     (log/info "Stopping aerospike client for hosts" hosts)
@@ -477,6 +477,10 @@
 
   Client policy configuration keys (see policy/create-client-policy)
   - :client-policy - a ready ClientPolicy
+  - :health-policy - a map of read-policy field overrides (string keys, same
+    format as `policy/map->policy`) applied on top of the client-policy's
+    `readPolicyDefault` to create the health-check read policy.
+    Defaults to `{\"totalTimeout\" 1000}`.
   - \"username\"
   - :port - to specify a single port to use for all host names, only if ports aren't
   explicit in the host names set above in `:hosts`. In case that a port isn't explicitly
@@ -490,7 +494,10 @@
    (let [close-event-loops?  (nil? (:event-loops conf))
          event-loops         (or (:event-loops conf) (create-event-loops conf))
          completion-executor (:completion-executor conf p-exec/default-executor)
-         client-policy       (:client-policy conf (policy/create-client-policy event-loops conf))]
+         client-policy       (:client-policy conf (policy/create-client-policy event-loops conf))
+         health-policy       (policy/map->health-policy
+                               (.readPolicyDefault ^ClientPolicy client-policy)
+                               (merge {"totalTimeout" 1000} (:health-policy conf)))]
      (log/info (format "Starting aerospike client for hosts %s with username %s" hosts (get conf "username")))
      (->SimpleAerospikeClient (create-client hosts client-policy (:port conf 3000))
                               event-loops
@@ -498,4 +505,5 @@
                               hosts
                               aero-ns
                               (utils/vectorize (:client-events conf))
-                              close-event-loops?))))
+                              close-event-loops?
+                              health-policy))))

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -114,7 +114,7 @@
                                 dbns
                                 client-events
                                 close-event-loops?
-                                health-policy]
+                                ^Policy health-policy]
   pt/AerospikeReadOps
   (get-single [this index set-name]
     (pt/get-single this index set-name {} [:all]))

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -434,7 +434,7 @@
         metrics/cluster-metrics->dotted))
 
   (healthy? [this]
-    (pt/healthy? this health-policy))
+    (pt/healthy? this 1000))
 
   (healthy? [this operation-timeout-ms]
     (let [health-policy (set! (.totalTimeout health-policy) operation-timeout-ms)

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -434,21 +434,17 @@
         metrics/cluster-metrics->dotted))
 
   (healthy? [this]
-    (pt/healthy? this 1000))
-
-  (healthy? [this operation-timeout-ms]
-    (let [health-policy (set! (.totalTimeout health-policy) operation-timeout-ms)
-       k           (str "__health__" (rand-int Integer/MAX_VALUE))
-       v           (rand-int Integer/MAX_VALUE)
-       ttl         (max 1 (int (/ operation-timeout-ms 1000)))
-       set-name    "__health-check"]
-   (try
-     @(pt/put this k set-name v ttl)
-     (= v
-        @(pt/get-single this k set-name {:transcoder :payload
-                                         :policy     health-policy}))
-     (catch Exception _ex
-       false))))
+    (let [k        (str "__health__" (rand-int Integer/MAX_VALUE))
+          v        (rand-int Integer/MAX_VALUE)
+          ttl      (max 1 (int (/ (.totalTimeout health-policy) 1000)))
+          set-name "__health-check"]
+      (try
+        @(pt/put this k set-name v ttl)
+        (= v
+           @(pt/get-single this k set-name {:transcoder :payload
+                                            :policy     health-policy}))
+        (catch Exception _ex
+          false))))
 
   (stop [_this]
     (log/info "Stopping aerospike client for hosts" hosts)

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -433,16 +433,15 @@
         metrics/cluster-metrics->dotted))
 
   (healthy? [this]
-    (pt/healthy? this 1000))
+    (let [p (Policy. (.readPolicyDefault ^AerospikeClient client))]
+      (set! (.totalTimeout p) 1000)
+      (pt/healthy? this p)))
 
-  (healthy? [this operation-timeout-ms]
-    (let [read-policy (let [p ^Policy (.readPolicyDefault ^AerospikeClient client)]
-                        (set! (.totalTimeout p) operation-timeout-ms)
-                        p)
-          k           (str "__health__" (rand-int Integer/MAX_VALUE))
-          v           (rand-int Integer/MAX_VALUE)
-          ttl         (min 1 (int (/ operation-timeout-ms 1000)))
-          set-name    "__health-check"]
+  (healthy? [this read-policy]
+    (let [k        (str "__health__" (rand-int Integer/MAX_VALUE))
+          v        (rand-int Integer/MAX_VALUE)
+          ttl      (max 1 (int (/ (.totalTimeout ^Policy read-policy) 1000)))
+          set-name "__health-check"]
       (try
         @(pt/put this k set-name v ttl)
         (= v

--- a/src/main/clojure/aerospike_clj/client.clj
+++ b/src/main/clojure/aerospike_clj/client.clj
@@ -239,9 +239,9 @@
 
   (put-multiple [this indices set-names payloads expirations conf]
     (p/all
-     (map (fn [[index set-name payload expiration]]
-            (pt/put this index set-name payload expiration conf))
-          (map vector indices set-names payloads expirations))))
+      (map (fn [[index set-name payload expiration]]
+             (pt/put this index set-name payload expiration conf))
+           (map vector indices set-names payloads expirations))))
 
   pt/AerospikeUpdateOps
   (set-single [this index set-name data expiration]

--- a/src/main/clojure/aerospike_clj/mock_client.clj
+++ b/src/main/clojure/aerospike_clj/mock_client.clj
@@ -254,8 +254,6 @@
   pt/AerospikeAdminOps
   (healthy? [_] true)
 
-  (healthy? [_ _] true)
-
   (get-cluster-stats [_] [[]])
 
   (stop [_]

--- a/src/main/clojure/aerospike_clj/policy.clj
+++ b/src/main/clojure/aerospike_clj/policy.clj
@@ -21,22 +21,30 @@
 (defn- throw-invalid-state [msg conf]
   (throw (ex-info msg {:conf (dissoc conf "password")})))
 
+(defn- apply-policy-fields
+  ^Policy [^Policy p conf]
+  (set-java-enum p conf "ReadModeAP")
+  (set-java-enum p conf "ReadModeSC")
+  (set-java p conf "maxRetries")
+  (set-java-enum p conf "Replica")
+  (set-java p conf "sendKey")
+  (set-java p conf "sleepBetweenRetries")
+  (set-java p conf "socketTimeout")
+  (set-java p conf "timeoutDelay")
+  (set-java p conf "totalTimeout")
+  p)
+
 (defn map->policy
   "Create a (read) `Policy` from a map. Enumeration names should start with capitalized letter.
   This function is slow due to possible reflection."
   ^Policy [conf]
-  (let [p    (Policy.)
-        conf (merge {"timeoutDelay" 3000} conf)]
-    (set-java-enum p conf "ReadModeAP")
-    (set-java-enum p conf "ReadModeSC")
-    (set-java p conf "maxRetries")
-    (set-java-enum p conf "Replica")
-    (set-java p conf "sendKey")
-    (set-java p conf "sleepBetweenRetries")
-    (set-java p conf "socketTimeout")
-    (set-java p conf "timeoutDelay")
-    (set-java p conf "totalTimeout")
-    p))
+  (apply-policy-fields (Policy.) (merge {"timeoutDelay" 3000} conf)))
+
+(defn map->health-policy
+  "Create a health-check read `Policy` by copying `base-policy` and applying
+  overrides from `conf`. Keys in `conf` use the same string format as `map->policy`."
+  ^Policy [^Policy base-policy conf]
+  (apply-policy-fields (Policy. base-policy) conf))
 
 (defn map->batch-write-policy
   "Create a `BatchWritePolicy` from a map. Enumeration names should start with capitalized letter.

--- a/src/main/clojure/aerospike_clj/protocols.clj
+++ b/src/main/clojure/aerospike_clj/protocols.clj
@@ -153,11 +153,12 @@
     The metric name is a dot separated string that should be convenient for
     reporting to statsd/graphite. All values are gauges.")
 
-  (healthy? [this] [this operation-timeout-ms]
+  (healthy? [this] [this read-policy]
     "Returns `true` iff the cluster is reachable and can take reads and writes.
-    Uses __health-check set to avoid data collisions. `operation-timeout-ms` is
-    for total timeout of reads (default is 1s) including 2 retries so a small
-    over estimation is advised to avoid false negatives.")
+    Uses __health-check set to avoid data collisions. `read-policy` is a
+    `com.aerospike.client.policy.Policy` used for the health-check read.
+    Prefer the `[this read-policy]` arity and supply a pre-built policy, as the
+    zero-arity creates a new `Policy` object on every call.")
 
   (stop [this]
     "Gracefully stop a client, waiting until all async operations finish.

--- a/src/main/clojure/aerospike_clj/protocols.clj
+++ b/src/main/clojure/aerospike_clj/protocols.clj
@@ -153,12 +153,11 @@
     The metric name is a dot separated string that should be convenient for
     reporting to statsd/graphite. All values are gauges.")
 
-  (healthy? [this] [this read-policy]
+  (healthy? [this] [this operation-timeout-ms] 
     "Returns `true` iff the cluster is reachable and can take reads and writes.
-    Uses __health-check set to avoid data collisions. `read-policy` is a
-    `com.aerospike.client.policy.Policy` used for the health-check read.
-    Prefer the `[this read-policy]` arity and supply a pre-built policy, as the
-    zero-arity creates a new `Policy` object on every call.")
+    Uses __health-check set to avoid data collisions. `operation-timeout-ms` is
+    for total timeout of reads (default is 1s) including 2 retries so a small
+    over estimation is advised to avoid false negatives.")
 
   (stop [this]
     "Gracefully stop a client, waiting until all async operations finish.

--- a/src/main/clojure/aerospike_clj/protocols.clj
+++ b/src/main/clojure/aerospike_clj/protocols.clj
@@ -153,11 +153,11 @@
     The metric name is a dot separated string that should be convenient for
     reporting to statsd/graphite. All values are gauges.")
 
-  (healthy? [this] [this operation-timeout-ms] 
+  (healthy? [this]
     "Returns `true` iff the cluster is reachable and can take reads and writes.
-    Uses __health-check set to avoid data collisions. `operation-timeout-ms` is
-    for total timeout of reads (default is 1s) including 2 retries so a small
-    over estimation is advised to avoid false negatives.")
+    Uses the __health-check set to avoid data collisions.
+    The check uses the client's configured health policy, which is derived at
+    initialization from `:health-policy` and defaults to a 1000ms `totalTimeout`.")
 
   (stop [this]
     "Gracefully stop a client, waiting until all async operations finish.

--- a/test/aerospike_clj/integration/integration_test.clj
+++ b/test/aerospike_clj/integration/integration_test.clj
@@ -56,7 +56,7 @@
         (is (no-password? ex))))))
 
 (deftest health
-  (is (true? (pt/healthy? *c* 10000))))
+  (is (true? (pt/healthy? *c*))))
 
 (defn random-key []
   (str (random-uuid)))

--- a/test/aerospike_clj/integration/integration_test.clj
+++ b/test/aerospike_clj/integration/integration_test.clj
@@ -56,7 +56,9 @@
         (is (no-password? ex))))))
 
 (deftest health
-  (is (true? (pt/healthy? *c* 10))))
+  (let [p (doto (Policy.)
+            (-> .-totalTimeout (set! 10000)))]
+    (is (true? (pt/healthy? *c* p)))))
 
 (defn random-key []
   (str (random-uuid)))

--- a/test/aerospike_clj/integration/integration_test.clj
+++ b/test/aerospike_clj/integration/integration_test.clj
@@ -56,9 +56,7 @@
         (is (no-password? ex))))))
 
 (deftest health
-  (let [p (doto (Policy.)
-            (-> .-totalTimeout (set! 10000)))]
-    (is (true? (pt/healthy? *c* p)))))
+  (is (true? (pt/healthy? *c* 10000))))
 
 (defn random-key []
   (str (random-uuid)))

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -286,7 +286,7 @@
         (is (empty @res))))))
 
 (deftest healthy-test
-  (is (= (pt/healthy? client 1000) true)))
+  (is (= (pt/healthy? client) true)))
 
 (deftest get-cluster-stats-test
   (is (= [[]] (pt/get-cluster-stats client))))

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -5,6 +5,7 @@
             [aerospike-clj.protocols :as pt]
             [clojure.string])
   (:import [com.aerospike.client ResultCode AerospikeException]
+           [com.aerospike.client.policy Policy]
            [java.util.concurrent ExecutionException]
            [aerospike_clj.client SimpleAerospikeClient]))
 
@@ -286,7 +287,7 @@
         (is (empty @res))))))
 
 (deftest healthy-test
-  (is (= (pt/healthy? client 0) true)))
+  (is (= (pt/healthy? client (Policy.)) true)))
 
 (deftest get-cluster-stats-test
   (is (= [[]] (pt/get-cluster-stats client))))

--- a/test/aerospike_clj/mock_client_test.clj
+++ b/test/aerospike_clj/mock_client_test.clj
@@ -5,7 +5,6 @@
             [aerospike-clj.protocols :as pt]
             [clojure.string])
   (:import [com.aerospike.client ResultCode AerospikeException]
-           [com.aerospike.client.policy Policy]
            [java.util.concurrent ExecutionException]
            [aerospike_clj.client SimpleAerospikeClient]))
 
@@ -287,7 +286,7 @@
         (is (empty @res))))))
 
 (deftest healthy-test
-  (is (= (pt/healthy? client (Policy.)) true)))
+  (is (= (pt/healthy? client 1000) true)))
 
 (deftest get-cluster-stats-test
   (is (= [[]] (pt/get-cluster-stats client))))

--- a/test/aerospike_clj/policy_test.clj
+++ b/test/aerospike_clj/policy_test.clj
@@ -1,7 +1,8 @@
 (ns aerospike-clj.policy-test
   (:require [clojure.test :refer [deftest is]]
             [aerospike-clj.policy :as policy])
-  (:import [com.aerospike.client.async EventPolicy]))
+  (:import (com.aerospike.client.async EventPolicy)
+           (com.aerospike.client.policy ReadModeAP ReadModeSC Replica)))
 
 (defn- verify-event-policy-properties
   ([^Exception event-policy]
@@ -30,3 +31,32 @@
           Exception
           #"setting maxCommandsInProcess>0 and maxCommandsInQueue=0 creates an unbounded delay queue"
           (policy/map->event-policy conf)))))
+
+(deftest get-health-policy-with-overrides
+  (let [base-conf      {"ReadModeAP"          "ALL"
+                        "ReadModeSC"          "SESSION"
+                        "maxRetries"          5
+                        "Replica"             "RANDOM"
+                        "sendKey"             true
+                        "sleepBetweenRetries"  100
+                        "socketTimeout"       3000
+                        "timeoutDelay"        4000
+                        "totalTimeout"        2000}
+        base-policy    (policy/map->policy base-conf)
+        health-policy  (policy/map->health-policy
+                        base-policy
+                        {"totalTimeout" 10000
+                         "sendKey"      false})]
+    (is (= 2000 (.totalTimeout base-policy)))
+    (is (= true (.sendKey base-policy)))
+    (is (= 5 (.maxRetries base-policy)))
+    (is (= 10000 (.totalTimeout health-policy)))
+    (is (= false (.sendKey health-policy)))
+    (is (= 5 (.maxRetries health-policy)))
+    (is (= ReadModeAP/ALL (.readModeAP health-policy)))
+    (is (= ReadModeSC/SESSION (.readModeSC health-policy)))
+    (is (= Replica/RANDOM (.replica health-policy)))
+    (is (= 100 (.sleepBetweenRetries health-policy)))
+    (is (= 3000 (.socketTimeout health-policy)))
+    (is (= 4000 (.timeoutDelay health-policy)))
+    (is (= 5 (.maxRetries health-policy)))))


### PR DESCRIPTION
### Fixed

* **BREAKING**: `AerospikeAdminOps/healthy?` now relies on the client's
  initialized health policy (default total timeout: 1000ms) instead of accepting
  a timeout override per call. This removes mutation of the shared
  `readPolicyDefault` on the underlying `AerospikeClient`, which previously
  could permanently overwrite the configured `totalTimeout`.

* Fixed a health check regression: the write TTL now uses `max 1` when deriving
  TTL from `:totalTimeout`, so very small timeouts no longer produce a `0`
  TTL (which could skip retention and make checks flaky).

### Changed   

* `AerospikeAdminOps/healthy?` protocol now exposes only the zero-arity
  `healthy? [this]` contract. Timeout customization is configured at client
  initialization via `:health-policy` instead of through the protocol call.

* `init-simple-aerospike-client` now accepts `:health-policy` in its `conf`
  map as string-keyed read-policy overrides. The configured value is applied on
  top of the resolved client policy's `readPolicyDefault`, with a default
  `{\"totalTimeout\" 1000}` fallback. This makes health check behavior
  configurable per client without mutating any shared default policy object.